### PR TITLE
fix: 9시간 깎이는 버그 수정

### DIFF
--- a/src/components/common/Game/GameTimer.tsx
+++ b/src/components/common/Game/GameTimer.tsx
@@ -1,4 +1,5 @@
 import useDate from '@/hooks/useDate';
+import { parseTime } from '@/utils/utc-times';
 
 interface GameTimerProps {
   date: Date;
@@ -13,7 +14,7 @@ export default function GameTimer({ date }: GameTimerProps) {
         {month}월 {day}일
       </p>
       <p>
-        {hour}:{minute}
+        {parseTime(hour)}:{parseTime(minute)}
       </p>
     </div>
   );

--- a/src/hooks/useDate.ts
+++ b/src/hooks/useDate.ts
@@ -3,7 +3,7 @@ export default function useDate(date: Date) {
   return {
     month: currentDate.getMonth() + 1,
     day: currentDate.getDate(),
-    hour: currentDate.getHours(),
+    hour: currentDate.getHours() + 9,
     minute: currentDate.getMinutes(),
   };
 }

--- a/src/utils/utc-times.ts
+++ b/src/utils/utc-times.ts
@@ -25,6 +25,6 @@ export const getUtcHours = (props: UtcHoursProps) => {
   );
 };
 
-const parseTime = (value: number) => {
+export const parseTime = (value: number) => {
   return value.toString().padStart(2, '0');
 };


### PR DESCRIPTION
## 작업 사항

- db에서 넘어오는 시간이 9시간씩 깎이는 버그 수정

## 참고 자료

- useDate()에서 hour에 + 9

## 기타

- utc-times.ts에서 parseTime export
