### PR TITLE
HOTFIX: 댓글 무한 api 호출 수정

### DIFF
--- a/src/api/game.ts
+++ b/src/api/game.ts
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/nextjs';
 import {
   AllGamesResponse,
   EachGameResponse,
-  GameCommentsResponse,
+  GameCommentResponse,
 } from '@/types/game';
 import instance from './instance';
 import { AxiosError, AxiosResponse } from 'axios';
@@ -47,7 +47,7 @@ export const getEachGame = async (gameID: number) => {
 
 export const getGameComments = async (gameID: number) => {
   try {
-    const response: AxiosResponse<GameCommentsResponse[]> = await instance.get(
+    const response: AxiosResponse<GameCommentResponse[]> = await instance.get(
       `/games/${gameID}/comments`,
     );
 

--- a/src/app/detail/[id]/page.tsx
+++ b/src/app/detail/[id]/page.tsx
@@ -13,11 +13,11 @@ export default function DetailPage({ params }: { params: { id: string } }) {
   const [gameData, setGameData] = useState<EachGameResponse>();
   const [isLoggedIn, setIsLoggedIn] = useState<boolean>(false);
 
-  const gameID = params.id;
+  const gameId = params.id;
 
   useEffect(() => {
     const getGameData = async () => {
-      const res = await getEachGame(Number(gameID));
+      const res = await getEachGame(Number(gameId));
 
       if (typeof res === 'number') return notFound();
 
@@ -26,28 +26,28 @@ export default function DetailPage({ params }: { params: { id: string } }) {
     getGameData();
     const token = localStorage.getItem('token');
     token && setIsLoggedIn(true);
-  }, [gameID]);
+  }, [gameId]);
 
   return (
     <div className="flex flex-col gap-8">
       {isLoggedIn && (
         <Link
-          href={`/detail/${gameID}/modify`}
-          className="p-2 rounded-lg border border-red-500 w-fit bg-red-400 text-white"
+          href={`/detail/${gameId}/modify`}
+          className="p-2 text-white bg-red-400 border border-red-500 rounded-lg w-fit"
         >
           수정
         </Link>
       )}
       {gameData && <GameInfo game={gameData} />}
       {isLoggedIn && (
-        <Link href={`/detail/${gameID}/status`} className="text-right">
+        <Link href={`/detail/${gameId}/status`} className="text-right">
           전/후반 변경하러 가기
         </Link>
       )}
       {gameData && (
         <GameTimeline records={gameData.records} status={gameData.gameStatus} />
       )}
-      {gameData && <GameComments gameID={gameData.id} />}
+      {gameData && <GameComments gameId={gameData.id} />}
     </div>
   );
 }

--- a/src/app/detail/[id]/page.tsx
+++ b/src/app/detail/[id]/page.tsx
@@ -25,7 +25,8 @@ export default function DetailPage({ params }: { params: { id: string } }) {
     };
     getGameData();
     const token = localStorage.getItem('token');
-    token && setIsLoggedIn(true);
+    if (!token) return;
+    setIsLoggedIn(true);
   }, [gameId]);
 
   return (

--- a/src/components/detail/GameComments.tsx
+++ b/src/components/detail/GameComments.tsx
@@ -14,7 +14,7 @@ export default function GameComments({ gameID }: { gameID: number }) {
   };
   useEffect(() => {
     getData();
-  }, [comments]);
+  }, []);
 
   const CommentSubmitHandler = async (
     event: React.FormEvent<HTMLFormElement>,

--- a/src/components/detail/GameComments.tsx
+++ b/src/components/detail/GameComments.tsx
@@ -5,23 +5,23 @@ import { GameCommentResponse } from '@/types/game';
 import { useEffect, useState } from 'react';
 import { Comment } from './Comment';
 
-export default function GameComments({ gameID }: { gameID: number }) {
+export default function GameComments({ gameId }: { gameId: number }) {
   const [comments, setComments] = useState<GameCommentResponse[]>();
   const [inputContent, setInputContent] = useState<string>('');
   const getData = async () => {
-    const res = await getGameComments(gameID);
+    const res = await getGameComments(gameId);
     typeof res !== 'number' && setComments(res);
   };
   useEffect(() => {
     getData();
-  }, []);
+  }, [gameId]);
 
   const CommentSubmitHandler = async (
     event: React.FormEvent<HTMLFormElement>,
   ) => {
     event.preventDefault();
     inputContent &&
-      (await postGameComment({ content: inputContent, gameId: gameID }));
+      (await postGameComment({ content: inputContent, gameId: gameId }));
     getData();
     setInputContent('');
   };
@@ -36,9 +36,9 @@ export default function GameComments({ gameID }: { gameID: number }) {
           value={inputContent}
           onChange={e => setInputContent(e.target.value)}
           placeholder="댓글을 작성하세요"
-          className="p-4 border-2 border-slate-400 rounded-lg w-full"
+          className="w-full p-4 border-2 rounded-lg border-slate-400"
         />
-        <div className="flex justify-between items-center">
+        <div className="flex items-center justify-between">
           <span className="text-xs text-gray-400">
             욕설 및 스포츠와 무관한 내용을 포함한 댓글은
             <br />
@@ -46,7 +46,7 @@ export default function GameComments({ gameID }: { gameID: number }) {
           </span>
           <button
             type="submit"
-            className="border border-slate-200 rounded-lg bg-green-600 text-white py-2 px-4  disabled:opacity-70 disabled:pointer-none float-right"
+            className="float-right px-4 py-2 text-white bg-green-600 border rounded-lg border-slate-200 disabled:opacity-70 disabled:pointer-none"
             disabled={inputContent.length == 0}
           >
             등록

--- a/src/components/detail/GameComments.tsx
+++ b/src/components/detail/GameComments.tsx
@@ -20,8 +20,9 @@ export default function GameComments({ gameId }: { gameId: number }) {
     event: React.FormEvent<HTMLFormElement>,
   ) => {
     event.preventDefault();
-    inputContent &&
-      (await postGameComment({ content: inputContent, gameId: gameId }));
+    if (!inputContent) return;
+
+    await postGameComment({ content: inputContent, gameId });
     getData();
     setInputContent('');
   };


### PR DESCRIPTION
## 작업 사항

- useEffect deps array에 집어넣은 comments 삭제로 댓글 get api 무한 호출 수정

## 참고 자료

- 작년에 공부했던 useEffect 안에 setState와 deps array에 state 집어넣는 행위의 위험성을 잠시 까먹었습니다..

## 기타

- GameCommentResponse 수정한거 api/game.ts에는 누락돼있어서 그것도 추가함
