### PR TITLE
[CHORE]: blue, gray 색상 팔레트 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "prepare": "husky install"
+    "prepare": "chmod ug+x .husky/* && husky install"
   },
   "lint-staged": {
     "**/*.{js, jsx, ts, tsx}": [

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -9,17 +9,17 @@ const config: Config = {
     extend: {
       colors: {
         blue: {
-          light: '#D3E2F6',
-          DEFAULT: '#4354F0',
-          heavy: '#303ECE',
+          primary: '#4354F0',
+          secondary: '#D3E2F6',
         },
         gray: {
-          extralight: '#F2F4F6',
-          light: '#E9E9E9',
-          DEFAULT: '#D9D9D9',
-          heavy: '#757575',
-          extraheavy: '#4E5968',
+          1: '#F7F8F9',
+          2: '#E9EBEE',
+          3: '#C5C8CE',
+          4: '#646F7C',
+          5: '#374553',
         },
+        black: '#14191F',
       },
     },
   },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,10 +8,8 @@ const config: Config = {
   theme: {
     extend: {
       colors: {
-        blue: {
-          primary: '#4354F0',
-          secondary: '#D3E2F6',
-        },
+        primary: '#4354F0',
+        secondary: '#D3E2F6',
         gray: {
           1: '#F7F8F9',
           2: '#E9EBEE',

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,12 +1,27 @@
-import type { Config } from "tailwindcss";
+import type { Config } from 'tailwindcss';
 
 const config: Config = {
   content: [
-    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+    './src/components/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/app/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        blue: {
+          light: '#D3E2F6',
+          DEFAULT: '#4354F0',
+          heavy: '#303ECE',
+        },
+        gray: {
+          extralight: '#F2F4F6',
+          light: '#E9E9E9',
+          DEFAULT: '#D9D9D9',
+          heavy: '#757575',
+          extraheavy: '#4E5968'
+        },
+      },
+    },
   },
   plugins: [],
 };

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -18,7 +18,7 @@ const config: Config = {
           light: '#E9E9E9',
           DEFAULT: '#D9D9D9',
           heavy: '#757575',
-          extraheavy: '#4E5968'
+          extraheavy: '#4E5968',
         },
       },
     },


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #56 

## ✅ 작업 내용

- blue, gray 색상 재정의

## 📝 참고 자료

blue는 3레벨, gray는 5레벨로 작성했습니다.
```js
colors: {
  blue: {
    light: '#D3E2F6',
    DEFAULT: '#4354F0',
    heavy: '#303ECE',
  },
  gray: {
    extralight: '#F2F4F6',
    light: '#E9E9E9',
    DEFAULT: '#D9D9D9',
    heavy: '#757575',
    extraheavy: '#4E5968'
  },
},
```
피그마에 아래처럼 각 색상이 적용되는 부분을 표시해놨으니 작업할 때 확인하시면 되겠습니다.
![image](https://github.com/hufs-sports-live/client/assets/87803596/a08e752a-6486-4ae3-84ed-4c8b7f864d97)
