### PR TITLE
[FIX]: os에 따라 husky가 동작하지 않는 버그 해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "prepare": "husky install"
+    "prepare": "chmod ug+x .husky/* && husky install"
   },
   "lint-staged": {
     "**/*.{js, jsx, ts, tsx}": [


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #58

## ✅ 작업 내용

- OS에 따라 husky 권한 문제가 발생하는 버그 해결
  - commit 실행 전에 `chmod ug+x .husky/*` 스크립트 실행
