### PR TITLE
[FEAT]: Icon 컴포넌트 및 데이터, 타입 추가

### DIFF
--- a/src/components/common/Icon/Icon.tsx
+++ b/src/components/common/Icon/Icon.tsx
@@ -1,0 +1,25 @@
+import { IconColor, IconName } from '@/types/icon';
+import { IconMap } from './IconMap';
+
+type IconProps = {
+  icon: IconName;
+  color: IconColor;
+  className?: string;
+};
+
+export const Icon = ({ icon, color, className }: IconProps) => {
+  const { width, height, path } = IconMap[icon];
+  return (
+    <svg
+      width={width}
+      height={height}
+      fill={color}
+      fillRule="evenodd"
+      clipRule="evenodd"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      <path d={path} />
+    </svg>
+  );
+};

--- a/src/components/common/Icon/IconMap.ts
+++ b/src/components/common/Icon/IconMap.ts
@@ -1,0 +1,28 @@
+export const IconMap = {
+  ic_hamburger_menu: {
+    width: 24,
+    height: 24,
+    path: 'M3.75 17.25a.75.75 0 0 1 .75-.75h15a.75.75 0 0 1 0 1.5h-15a.75.75 0 0 1-.75-.75ZM3.75 11.25a.75.75 0 0 1 .75-.75h15a.75.75 0 0 1 0 1.5h-15a.75.75 0 0 1-.75-.75ZM3.75 5.25a.75.75 0 0 1 .75-.75h15a.75.75 0 0 1 0 1.5h-15a.75.75 0 0 1-.75-.75Z',
+  },
+  ic_cross: {
+    width: 24,
+    height: 24,
+    path: 'm7.757 16.243 8.486-8.486M16.243 16.243 7.757 7.757',
+  },
+};
+
+export const ICON_NAME = {
+  ic_hamburger_menu: 'ic_hamburger_menu',
+  ic_cross: 'ic_cross',
+} as const;
+
+export const ICON_COLOR = {
+  'blue-light': 'blue-light',
+  blue: 'blue',
+  'blue-heavy': 'blue-heavy',
+  'gray-extralight': 'gray-extralight',
+  'gray-light': 'gray-light',
+  gray: 'gray',
+  'gray-heavy': 'gray-heavy',
+  'gray-extraheavy': 'gray-extraheavy',
+} as const;

--- a/src/types/icon.ts
+++ b/src/types/icon.ts
@@ -1,0 +1,4 @@
+import { ICON_COLOR, ICON_NAME } from '@/components/common/Icon/IconMap';
+
+export type IconName = (typeof ICON_NAME)[keyof typeof ICON_NAME];
+export type IconColor = (typeof ICON_COLOR)[keyof typeof ICON_COLOR];

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,12 +1,27 @@
-import type { Config } from "tailwindcss";
+import type { Config } from 'tailwindcss';
 
 const config: Config = {
   content: [
-    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+    './src/components/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/app/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        blue: {
+          light: '#D3E2F6',
+          DEFAULT: '#4354F0',
+          heavy: '#303ECE',
+        },
+        gray: {
+          extralight: '#F2F4F6',
+          light: '#E9E9E9',
+          DEFAULT: '#D9D9D9',
+          heavy: '#757575',
+          extraheavy: '#4E5968'
+        },
+      },
+    },
   },
   plugins: [],
 };

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -18,7 +18,7 @@ const config: Config = {
           light: '#E9E9E9',
           DEFAULT: '#D9D9D9',
           heavy: '#757575',
-          extraheavy: '#4E5968'
+          extraheavy: '#4E5968',
         },
       },
     },


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #56 

## ✅ 작업 내용

- Icon 컴포넌트 생성
  - svg에 주입할 width, height, path d값을 가진 IconMap 생성
  - Icon 컴포넌트 선언시 주입할 icon과 color 프로퍼티의 타입 추가

## 📝 참고 자료

- [쏘카 React Custom Icon Component 개발기](https://tech.socarcorp.kr/dev/2022/09/06/react-icon-component.html)
- [React에서 Icon 다루기](https://blog.toycrane.xyz/react%EC%97%90%EC%84%9C-icon-%EB%8B%A4%EB%A3%A8%EA%B8%B0-59b6d987d61f)

## ♾️ 기타

- 현재 Icon을 svg파일로 저장하는 것이 아닌 IconMap.ts의 IconMap 객체에 string으로 저장하는 방식을 채택했습니다.
  - 기존 Icon을 저장하면 path 태그가 여러개 생기는 것을 [SVGOMG](https://jakearchibald.github.io/svgomg/) 사이트를 통해(또는 SVGR 웹팩 플러그인) 1줄의 string으로 파싱해 저장하도록 변경하였습니다.
  - path를 파싱하는 이유는 svg 이미지 최적화로 최대 50%까지 용량을 줄일 수 있게 됩니다.
  - 파싱 방법에는 2가지가 있습니다.
    - SVGOMG 사이트에 접속해 파일을 수동으로 업로드 및 최적화해 다운로드 후 path값을 객체에 기입해줄 수 있습니다.
    - SVGR 플러그인을 설치해 특정 폴더에 svg파일을 위치시키고 커맨드를 실행하면 자동으로 매핑된 객체를 생성할 수 있습니다.
  - 현재는 일일이 수동으로 사이트에 접속해 최적화하는 방식을 채택했습니다.
  - 그 이유로 아이콘이 많지 않은 점, 그리고 SVGR 플러그인 의존성을 설치하는 것이 불필요하다 판단했기 때문입니다.

- 쏘카 개발기에서 IconName과 IconColor 타입을 리터럴 타입으로 지정해줬지만 어떤 이유에서인지 자동완성이 실행되지 않는 버그가 있습니다.

- 이 브랜치의 base인 chore/color-palette에서의 네이밍 컨벤션이 확정되면 추후 IconMap.ts의 컬러명도 수정할 예정입니다.
