### PR TITLE
[FEAT]: 헤더 타이틀 영역 라우트에 따른 내용물 전환 기능

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     ]
   },
   "dependencies": {
+    "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-icons": "^1.3.0",
     "@sentry/nextjs": "^7.73.0",
     "@tanstack/react-query": "^5.8.2",

--- a/src/api/league.ts
+++ b/src/api/league.ts
@@ -5,7 +5,7 @@ import instance from './instance';
 
 export type LeagueType = {
   name: string;
-  leagueId?: number;
+  leagueId: number;
 };
 
 export const getAllLeagues = async () => {

--- a/src/api/league.ts
+++ b/src/api/league.ts
@@ -1,0 +1,27 @@
+import * as Sentry from '@sentry/nextjs';
+import { AxiosError } from 'axios';
+
+import instance from './instance';
+
+export type LeagueType = {
+  name: string;
+  leagueId?: number;
+};
+
+export const getAllLeagues = async () => {
+  try {
+    const response = await instance.get<LeagueType[]>('/leagues');
+
+    return response.data;
+  } catch (error) {
+    const axiosError = error as AxiosError;
+
+    Sentry.captureException(axiosError);
+
+    if (axiosError.response) {
+      throw new Error(axiosError.response.statusText);
+    } else {
+      throw new Error('리그 목록을 불러오는 데에 실패했습니다!');
+    }
+  }
+};

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,10 +28,10 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={`${inter.className} m-auto max-w-md bg-slate-50 p-4`}>
+      <body className={`${inter.className} m-auto max-w-md bg-slate-50`}>
         <ReactQueryProvider>
           <Header />
-          {children}
+          <main className="p-4">{children}</main>
           <Footer />
         </ReactQueryProvider>
       </body>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,10 +28,10 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={`${inter.className} m-auto max-w-md bg-slate-50`}>
+      <body className={`${inter.className} m-auto max-w-md`}>
         <ReactQueryProvider>
           <Header />
-          <main className="p-4">{children}</main>
+          <main className="px-4">{children}</main>
           <Footer />
         </ReactQueryProvider>
       </body>

--- a/src/components/common/Modal/index.tsx
+++ b/src/components/common/Modal/index.tsx
@@ -1,0 +1,49 @@
+import * as Dialog from '@radix-ui/react-dialog';
+import { ReactNode } from 'react';
+
+import { Icon } from '@/components/common/Icon';
+import { $ } from '@/utils/core';
+
+type ModalProps = {
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  children: ReactNode;
+};
+
+export default function Modal({ open, onOpenChange, children }: ModalProps) {
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      {children}
+    </Dialog.Root>
+  );
+}
+
+function ModalContent({
+  title,
+  className,
+  children,
+}: {
+  title: string;
+  className: string;
+  children: ReactNode;
+}) {
+  return (
+    <Dialog.Portal>
+      <Dialog.Overlay className="fixed inset-0 bg-black/50 data-[state=closed]:animate-[dialog-overlay-hide_200ms] data-[state=open]:animate-[dialog-overlay-show_200ms]" />
+      <Dialog.Content className={$('fixed', className)}>
+        <div className="flex items-center justify-between">
+          <Dialog.Title className="text-xl">{title}</Dialog.Title>
+          <Dialog.Close className="text-gray-400 hover:text-gray-500">
+            <Icon iconName="cross" />
+          </Dialog.Close>
+        </div>
+
+        {children}
+      </Dialog.Content>
+    </Dialog.Portal>
+  );
+}
+
+Modal.Trigger = Dialog.Trigger;
+Modal.Content = ModalContent;
+Modal.Close = Dialog.Close;

--- a/src/components/common/Sidebar/index.tsx
+++ b/src/components/common/Sidebar/index.tsx
@@ -1,0 +1,52 @@
+'use client';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
+import { getAllLeagues, LeagueType } from '@/api/league';
+
+type SidebarProps = {
+  onClickChange: () => void;
+};
+
+export default function Sidebar({ onClickChange }: SidebarProps) {
+  const [menuContent, setMenuContent] = useState<LeagueType[]>([
+    { name: '전체' },
+  ]);
+
+  useEffect(() => {
+    const getLeagueData = async () => {
+      const res = await getAllLeagues();
+
+      if (typeof res === 'number') return;
+
+      setMenuContent(prev => [...prev, ...res]);
+    };
+
+    getLeagueData();
+  }, []);
+
+  return (
+    <div>
+      <div
+        className="fixed inset-0 bg-black/50"
+        onClick={onClickChange}
+        aria-hidden="true"
+      />
+      <aside className="fixed right-0 top-0 z-40 h-screen w-64 bg-gray-1 p-5 py-8">
+        <ul className="overflow-y-auto text-gray-5">
+          <div className="my-2 text-xl font-semibold">대회 목록</div>
+          {menuContent.map(content => (
+            <Link
+              href={{ pathname: '/', query: { leagueId: content.leagueId } }}
+              onClick={onClickChange}
+              key={content.name}
+              className="flex items-center rounded-lg p-2 hover:bg-gray-2 dark:text-white dark:hover:bg-gray-5"
+            >
+              {content.name}
+            </Link>
+          ))}
+        </ul>
+      </aside>
+    </div>
+  );
+}

--- a/src/components/common/Sidebar/index.tsx
+++ b/src/components/common/Sidebar/index.tsx
@@ -34,7 +34,11 @@ export default function Sidebar({ onClickSidebar }: SidebarProps) {
         <div className="my-2 text-xl font-semibold">대회 목록</div>
         <ul className="overflow-y-auto ">
           {menuContent.map(content => (
-            <li key={content.name} onClick={onClickSidebar} aria-hidden="true">
+            <li
+              key={content.leagueId}
+              onClick={onClickSidebar}
+              aria-hidden="true"
+            >
               <Link
                 href={{ pathname: '/', query: { leagueId: content.leagueId } }}
                 className="flex items-center rounded-lg p-2 hover:bg-gray-2 dark:text-white dark:hover:bg-gray-5"

--- a/src/components/common/Sidebar/index.tsx
+++ b/src/components/common/Sidebar/index.tsx
@@ -1,23 +1,21 @@
 'use client';
+
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 
 import { getAllLeagues, LeagueType } from '@/api/league';
 
 type SidebarProps = {
-  onClickChange: () => void;
+  onClickSidebar: () => void;
 };
-
-export default function Sidebar({ onClickChange }: SidebarProps) {
+export default function Sidebar({ onClickSidebar }: SidebarProps) {
   const [menuContent, setMenuContent] = useState<LeagueType[]>([
-    { name: '전체' },
+    { name: '전체', leagueId: 0 },
   ]);
 
   useEffect(() => {
     const getLeagueData = async () => {
       const res = await getAllLeagues();
-
-      if (typeof res === 'number') return;
 
       setMenuContent(prev => [...prev, ...res]);
     };
@@ -26,27 +24,27 @@ export default function Sidebar({ onClickChange }: SidebarProps) {
   }, []);
 
   return (
-    <div>
+    <aside>
       <div
         className="fixed inset-0 bg-black/50"
-        onClick={onClickChange}
+        onClick={onClickSidebar}
         aria-hidden="true"
       />
-      <aside className="fixed right-0 top-0 z-40 h-screen w-64 bg-gray-1 p-5 py-8">
-        <ul className="overflow-y-auto text-gray-5">
-          <div className="my-2 text-xl font-semibold">대회 목록</div>
+      <div className="fixed right-0 top-0 z-40 h-screen w-64 bg-gray-1 p-5 py-8 text-gray-5">
+        <div className="my-2 text-xl font-semibold">대회 목록</div>
+        <ul className="overflow-y-auto ">
           {menuContent.map(content => (
-            <Link
-              href={{ pathname: '/', query: { leagueId: content.leagueId } }}
-              onClick={onClickChange}
-              key={content.name}
-              className="flex items-center rounded-lg p-2 hover:bg-gray-2 dark:text-white dark:hover:bg-gray-5"
-            >
-              {content.name}
-            </Link>
+            <li key={content.name} onClick={onClickSidebar} aria-hidden="true">
+              <Link
+                href={{ pathname: '/', query: { leagueId: content.leagueId } }}
+                className="flex items-center rounded-lg p-2 hover:bg-gray-2 dark:text-white dark:hover:bg-gray-5"
+              >
+                {content.name}
+              </Link>
+            </li>
           ))}
         </ul>
-      </aside>
-    </div>
+      </div>
+    </aside>
   );
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,30 +1,37 @@
 'use client';
 
 import { useSelectedLayoutSegments } from 'next/navigation';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Icon } from '@/components/common/Icon';
 import Sidebar from '@/components/common/Sidebar';
 import { $ } from '@/utils/core';
 
 export default function Header() {
-  const [open, setOpen] = useState(false);
-  const isAuthenticated =
-    typeof window !== 'undefined' &&
-    typeof localStorage.getItem('token') === 'string';
+  const segments = useSelectedLayoutSegments();
+  const titleContent = segments.includes('match') ? 'Match' : '훕치치';
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
 
-  const handleOpenSidebar = () => setOpen(prev => !prev);
+  const toggleSidebar = () => setIsSidebarOpen(prev => !prev);
+
+  useEffect(() => {
+    setIsAuthenticated(typeof localStorage.getItem('token') === 'string');
+  }, []);
 
   return (
-    <div
+    <header
       className={$(
         'flex items-center justify-between p-4',
         isAuthenticated && 'bg-primary text-white',
       )}
     >
-      <HeaderTitle isAuthenticated={isAuthenticated} />
+      <div className="flex items-baseline gap-1 text-center">
+        <span className="text-3xl font-bold">{titleContent}</span>
+        {isAuthenticated && <span className="">관리자</span>}
+      </div>
       <section>
-        <button onClick={handleOpenSidebar}>
+        <button onClick={toggleSidebar}>
           <Icon
             iconName="hamburgerMenu"
             width={32}
@@ -33,24 +40,8 @@ export default function Header() {
             className={isAuthenticated ? 'fill-white' : 'fill-primary'}
           />
         </button>
-        {open && <Sidebar onClickChange={handleOpenSidebar} />}
+        {isSidebarOpen && <Sidebar onClickSidebar={toggleSidebar} />}
       </section>
-    </div>
-  );
-}
-
-type HeaderTitleProps = {
-  isAuthenticated: boolean;
-};
-function HeaderTitle({ isAuthenticated }: HeaderTitleProps) {
-  const segments = useSelectedLayoutSegments();
-  const titleContent = segments.includes('match') ? 'Match' : '훕치치';
-  // <Icon iconName="logo" />
-
-  return (
-    <div className="flex items-baseline gap-1 text-center">
-      <span className="text-3xl font-bold">{titleContent}</span>
-      {isAuthenticated && <span className="">관리자</span>}
-    </div>
+    </header>
   );
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,9 +1,28 @@
+'use client';
+
+import { useSelectedLayoutSegments } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
 import { Icon } from '../common/Icon';
 
 export default function Header() {
+  const segments = useSelectedLayoutSegments();
+  const [titleContent, setTitleContent] = useState<JSX.Element | string>(
+    <Icon iconName="hamburgerMenu" />,
+  );
+
+  useEffect(() => {
+    if (segments.includes('admin')) {
+      setTitleContent('관리자');
+    }
+    if (segments.includes('detail')) {
+      setTitleContent('Match');
+    }
+  }, []);
+
   return (
     <div className="flex items-center justify-between">
-      <div className="text-3xl font-bold">Match</div>
+      <div className="text-3xl font-bold">{titleContent}</div>
 
       <Icon
         iconName="hamburgerMenu"

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,15 +1,26 @@
 'use client';
 
-import { useSelectedLayoutSegments } from 'next/navigation';
+import Link from 'next/link';
+import { notFound, useSelectedLayoutSegments } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
-import { Icon } from '../common/Icon';
+import { getAllLeagues, LeagueType } from '@/api/league';
+import { Icon } from '@/components/common/Icon';
+import Modal from '@/components/common/Modal';
 
 export default function Header() {
   const segments = useSelectedLayoutSegments();
   const [titleContent, setTitleContent] = useState<JSX.Element | string>(
     <Icon iconName="hamburgerMenu" />,
   );
+  const [menuContent, setMenuContent] = useState<LeagueType[]>([
+    { name: '전체' },
+  ]);
+  const [open, setOpen] = useState(false);
+
+  const handleClickLink = () => {
+    setOpen(false);
+  };
 
   useEffect(() => {
     if (segments.includes('admin')) {
@@ -18,19 +29,50 @@ export default function Header() {
     if (segments.includes('detail')) {
       setTitleContent('Match');
     }
+
+    const getLeagueData = async () => {
+      const res = await getAllLeagues();
+
+      if (typeof res === 'number') return notFound();
+
+      setMenuContent(prev => [...prev, ...res]);
+    };
+
+    getLeagueData();
   }, []);
 
   return (
     <div className="flex items-center justify-between">
       <div className="text-3xl font-bold">{titleContent}</div>
 
-      <Icon
-        iconName="hamburgerMenu"
-        width={32}
-        height={32}
-        viewBox="0 0 24 24"
-        className="fill-primary"
-      />
+      <Modal open={open} onOpenChange={setOpen}>
+        <Modal.Trigger>
+          <Icon
+            iconName="hamburgerMenu"
+            width={32}
+            height={32}
+            viewBox="0 0 24 24"
+            className="fill-primary"
+          />
+        </Modal.Trigger>
+
+        <Modal.Content
+          title="대회 목록"
+          className="right-0 top-0 h-screen w-52 space-y-4 bg-white p-5 py-8 data-[state=closed]:animate-[menu-content-hide_200ms] data-[state=open]:animate-[menu-content-show_200ms]"
+        >
+          <div className="flex flex-col gap-2">
+            {menuContent.map(content => (
+              <Link
+                href={{ pathname: '/', query: { leagueId: content.leagueId } }}
+                onClick={handleClickLink}
+                key={content.name}
+              >
+                {content.name}
+              </Link>
+            ))}
+          </div>
+        </Modal.Content>
+      </Modal>
     </div>
   );
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -7,29 +7,20 @@ import { useEffect, useState } from 'react';
 import { getAllLeagues, LeagueType } from '@/api/league';
 import { Icon } from '@/components/common/Icon';
 import Modal from '@/components/common/Modal';
+import { $ } from '@/utils/core';
 
 export default function Header() {
-  const segments = useSelectedLayoutSegments();
-  const [titleContent, setTitleContent] = useState<JSX.Element | string>(
-    <Icon iconName="hamburgerMenu" />,
-  );
   const [menuContent, setMenuContent] = useState<LeagueType[]>([
     { name: '전체' },
   ]);
   const [open, setOpen] = useState(false);
+  const isAuthenticated = typeof localStorage.getItem('token') === 'string';
 
   const handleClickLink = () => {
     setOpen(false);
   };
 
   useEffect(() => {
-    if (segments.includes('admin')) {
-      setTitleContent('관리자');
-    }
-    if (segments.includes('detail')) {
-      setTitleContent('Match');
-    }
-
     const getLeagueData = async () => {
       const res = await getAllLeagues();
 
@@ -42,8 +33,13 @@ export default function Header() {
   }, []);
 
   return (
-    <div className="flex items-center justify-between">
-      <div className="text-3xl font-bold">{titleContent}</div>
+    <div
+      className={$(
+        'flex items-center justify-between p-4',
+        isAuthenticated && 'bg-primary text-white',
+      )}
+    >
+      <HeaderTitle isAuthenticated={isAuthenticated} />
 
       <Modal open={open} onOpenChange={setOpen}>
         <Modal.Trigger>
@@ -52,7 +48,7 @@ export default function Header() {
             width={32}
             height={32}
             viewBox="0 0 24 24"
-            className="fill-primary"
+            className={isAuthenticated ? 'fill-white' : 'fill-primary'}
           />
         </Modal.Trigger>
 
@@ -73,6 +69,22 @@ export default function Header() {
           </div>
         </Modal.Content>
       </Modal>
+    </div>
+  );
+}
+
+type HeaderTitleProps = {
+  isAuthenticated: boolean;
+};
+function HeaderTitle({ isAuthenticated }: HeaderTitleProps) {
+  const segments = useSelectedLayoutSegments();
+  const titleContent = segments.includes('match') ? 'Match' : '훕치치';
+  // <Icon iconName="logo" />
+
+  return (
+    <div className="flex items-baseline gap-1 text-center">
+      <span className="text-3xl font-bold">{titleContent}</span>
+      {isAuthenticated && <span className="">관리자</span>}
     </div>
   );
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -28,7 +28,7 @@ export default function Header() {
     >
       <div className="flex items-baseline gap-1 text-center">
         <span className="text-3xl font-bold">{titleContent}</span>
-        {isAuthenticated && <span className="">관리자</span>}
+        {isAuthenticated && <span>관리자</span>}
       </div>
       <section>
         <button onClick={toggleSidebar}>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,36 +1,19 @@
 'use client';
 
-import Link from 'next/link';
-import { notFound, useSelectedLayoutSegments } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useSelectedLayoutSegments } from 'next/navigation';
+import { useState } from 'react';
 
-import { getAllLeagues, LeagueType } from '@/api/league';
 import { Icon } from '@/components/common/Icon';
-import Modal from '@/components/common/Modal';
+import Sidebar from '@/components/common/Sidebar';
 import { $ } from '@/utils/core';
 
 export default function Header() {
-  const [menuContent, setMenuContent] = useState<LeagueType[]>([
-    { name: '전체' },
-  ]);
   const [open, setOpen] = useState(false);
-  const isAuthenticated = typeof localStorage.getItem('token') === 'string';
+  const isAuthenticated =
+    typeof window !== 'undefined' &&
+    typeof localStorage.getItem('token') === 'string';
 
-  const handleClickLink = () => {
-    setOpen(false);
-  };
-
-  useEffect(() => {
-    const getLeagueData = async () => {
-      const res = await getAllLeagues();
-
-      if (typeof res === 'number') return notFound();
-
-      setMenuContent(prev => [...prev, ...res]);
-    };
-
-    getLeagueData();
-  }, []);
+  const handleOpenSidebar = () => setOpen(prev => !prev);
 
   return (
     <div
@@ -40,9 +23,8 @@ export default function Header() {
       )}
     >
       <HeaderTitle isAuthenticated={isAuthenticated} />
-
-      <Modal open={open} onOpenChange={setOpen}>
-        <Modal.Trigger>
+      <section>
+        <button onClick={handleOpenSidebar}>
           <Icon
             iconName="hamburgerMenu"
             width={32}
@@ -50,25 +32,9 @@ export default function Header() {
             viewBox="0 0 24 24"
             className={isAuthenticated ? 'fill-white' : 'fill-primary'}
           />
-        </Modal.Trigger>
-
-        <Modal.Content
-          title="대회 목록"
-          className="right-0 top-0 h-screen w-52 space-y-4 bg-white p-5 py-8 data-[state=closed]:animate-[menu-content-hide_200ms] data-[state=open]:animate-[menu-content-show_200ms]"
-        >
-          <div className="flex flex-col gap-2">
-            {menuContent.map(content => (
-              <Link
-                href={{ pathname: '/', query: { leagueId: content.leagueId } }}
-                onClick={handleClickLink}
-                key={content.name}
-              >
-                {content.name}
-              </Link>
-            ))}
-          </div>
-        </Modal.Content>
-      </Modal>
+        </button>
+        {open && <Sidebar onClickChange={handleOpenSidebar} />}
+      </section>
     </div>
   );
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -19,6 +19,36 @@ const config: Config = {
         },
         black: '#14191F',
       },
+      keyframes: {
+        'dialog-overlay-show': {
+          '0%': { opacity: '0' },
+          '100%': { opacity: '1' },
+        },
+        'dialog-overlay-hide': {
+          '0%': { opacity: '1' },
+          '100%': { opacity: '0' },
+        },
+        'menu-content-show': {
+          '0%': {
+            opacity: '0',
+            transform: 'translate(25%)',
+          },
+          '100%': {
+            opacity: '1',
+            transform: 'translate(0%)',
+          },
+        },
+        'menu-content-hide': {
+          '0%': {
+            opacity: '1',
+            transform: 'translate(0%)',
+          },
+          '100%': {
+            opacity: '0',
+            transform: 'translate(25%)',
+          },
+        },
+      },
     },
   },
   plugins: [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,6 +34,13 @@
     chalk "^2.4.2"
     js-tokens "^4.0.0"
 
+"@babel/runtime@^7.13.10":
+  version "7.23.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.4.tgz#36fa1d2b36db873d25ec631dcc4923fdc1cf2e2e"
+  integrity sha512-2Yv65nlWnWlSpe3fXEyX5i7fx5kIKo4Qbcj+hMO0odwaneFjfXw5fdum+4yL20O0QiaHpia0cYQ9xpNMqrBwHg==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/runtime@^7.20.7":
   version "7.23.1"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.1.tgz#72741dc4d413338a91dcb044a86f3c0bc402646d"
@@ -385,10 +392,152 @@
     picocolors "^1.0.0"
     tslib "^2.6.0"
 
+"@radix-ui/primitive@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.0.1.tgz#e46f9958b35d10e9f6dc71c497305c22e3e55dbd"
+  integrity sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-compose-refs@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz#7ed868b66946aa6030e580b1ffca386dd4d21989"
+  integrity sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-context@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.0.1.tgz#fe46e67c96b240de59187dcb7a1a50ce3e2ec00c"
+  integrity sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-dialog@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dialog/-/react-dialog-1.0.5.tgz#71657b1b116de6c7a0b03242d7d43e01062c7300"
+  integrity sha512-GjWJX/AUpB703eEBanuBnIWdIXg6NvJFCXcNlSZk4xdszCdhrJgBoUd1cGk67vFO+WdA2pfI/plOpqz/5GUP6Q==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-dismissable-layer" "1.0.5"
+    "@radix-ui/react-focus-guards" "1.0.1"
+    "@radix-ui/react-focus-scope" "1.0.4"
+    "@radix-ui/react-id" "1.0.1"
+    "@radix-ui/react-portal" "1.0.4"
+    "@radix-ui/react-presence" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-slot" "1.0.2"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+    aria-hidden "^1.1.1"
+    react-remove-scroll "2.5.5"
+
+"@radix-ui/react-dismissable-layer@1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.5.tgz#3f98425b82b9068dfbab5db5fff3df6ebf48b9d4"
+  integrity sha512-aJeDjQhywg9LBu2t/At58hCvr7pEm0o2Ke1x33B+MhjNmmZ17sy4KImo0KPLgsnc/zN7GPdce8Cnn0SWvwZO7g==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+    "@radix-ui/react-use-escape-keydown" "1.0.3"
+
+"@radix-ui/react-focus-guards@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-guards/-/react-focus-guards-1.0.1.tgz#1ea7e32092216b946397866199d892f71f7f98ad"
+  integrity sha512-Rect2dWbQ8waGzhMavsIbmSVCgYxkXLxxR3ZvCX79JOglzdEy4JXMb98lq4hPxUbLr77nP0UOGf4rcMU+s1pUA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-focus-scope@1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-scope/-/react-focus-scope-1.0.4.tgz#2ac45fce8c5bb33eb18419cdc1905ef4f1906525"
+  integrity sha512-sL04Mgvf+FmyvZeYfNu1EPAaaxD+aw7cYeIB9L9Fvq8+urhltTRaEo5ysKOpHuKPclsZcSUMKlN05x4u+CINpA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+
 "@radix-ui/react-icons@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-icons/-/react-icons-1.3.0.tgz#c61af8f323d87682c5ca76b856d60c2312dbcb69"
   integrity sha512-jQxj/0LKgp+j9BiTXz3O3sgs26RNet2iLWmsPyRz2SIcR4q/4SbazXfnYwbAr+vLYKSfc7qxzyGQA1HLlYiuNw==
+
+"@radix-ui/react-id@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-id/-/react-id-1.0.1.tgz#73cdc181f650e4df24f0b6a5b7aa426b912c88c0"
+  integrity sha512-tI7sT/kqYp8p96yGWY1OAnLHrqDgzHefRBKQ2YAkBS5ja7QLcZ9Z/uY7bEjPUatf8RomoXM8/1sMj1IJaE5UzQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
+
+"@radix-ui/react-portal@1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-1.0.4.tgz#df4bfd353db3b1e84e639e9c63a5f2565fb00e15"
+  integrity sha512-Qki+C/EuGUVCQTOTD5vzJzJuMUlewbzuKyUy+/iHM2uwGiru9gZeBJtHAPKAEkB5KWGi9mP/CHKcY0wt1aW45Q==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-primitive" "1.0.3"
+
+"@radix-ui/react-presence@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-1.0.1.tgz#491990ba913b8e2a5db1b06b203cb24b5cdef9ba"
+  integrity sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
+
+"@radix-ui/react-primitive@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-1.0.3.tgz#d49ea0f3f0b2fe3ab1cb5667eb03e8b843b914d0"
+  integrity sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-slot" "1.0.2"
+
+"@radix-ui/react-slot@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.0.2.tgz#a9ff4423eade67f501ffb32ec22064bc9d3099ab"
+  integrity sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.1"
+
+"@radix-ui/react-use-callback-ref@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz#f4bb1f27f2023c984e6534317ebc411fc181107a"
+  integrity sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-use-controllable-state@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.1.tgz#ecd2ced34e6330caf89a82854aa2f77e07440286"
+  integrity sha512-Svl5GY5FQeN758fWKrjM6Qb7asvXeiZltlT4U2gVfl8Gx5UAv2sMR0LWo8yhsIZh2oQ0eFdZ59aoOOMV7b47VA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+
+"@radix-ui/react-use-escape-keydown@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.0.3.tgz#217b840c250541609c66f67ed7bab2b733620755"
+  integrity sha512-vyL82j40hcFicA+M4Ex7hVkB9vHgSse1ZWomAqV2Je3RleKGO5iM8KMOEtfoSB0PnIelMd2lATjTGMYqN5ylTg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+
+"@radix-ui/react-use-layout-effect@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.1.tgz#be8c7bc809b0c8934acf6657b577daf948a75399"
+  integrity sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
 
 "@rollup/plugin-commonjs@24.0.0":
   version "24.0.0"
@@ -953,6 +1102,13 @@ argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
+aria-hidden@^1.1.1:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/aria-hidden/-/aria-hidden-1.2.3.tgz#14aeb7fb692bbb72d69bebfa47279c1fd725e954"
+  integrity sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==
+  dependencies:
+    tslib "^2.0.0"
 
 aria-query@^5.1.3, aria-query@^5.3.0:
   version "5.3.0"
@@ -1520,6 +1676,11 @@ dequal@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
   integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
+
+detect-node-es@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/detect-node-es/-/detect-node-es-1.1.0.tgz#163acdf643330caa0b4cd7c21e7ee7755d6fa493"
+  integrity sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==
 
 didyoumean@^1.2.2:
   version "1.2.2"
@@ -2202,6 +2363,11 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@
     has-proto "^1.0.1"
     has-symbols "^1.0.3"
 
+get-nonce@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/get-nonce/-/get-nonce-1.0.1.tgz#fdf3f0278073820d2ce9426c18f07481b1e0cdf3"
+  integrity sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==
+
 get-stream@^6.0.0, get-stream@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
@@ -2511,6 +2677,13 @@ internal-slot@^1.0.5:
     get-intrinsic "^1.2.0"
     has "^1.0.3"
     side-channel "^1.0.4"
+
+invariant@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
+  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
+  dependencies:
+    loose-envify "^1.0.0"
 
 is-array-buffer@^3.0.1, is-array-buffer@^3.0.2:
   version "3.0.2"
@@ -3033,7 +3206,7 @@ log-update@^5.0.1:
     strip-ansi "^7.0.1"
     wrap-ansi "^8.0.1"
 
-loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -3623,6 +3796,34 @@ react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-remove-scroll-bar@^2.3.3:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.4.tgz#53e272d7a5cb8242990c7f144c44d8bd8ab5afd9"
+  integrity sha512-63C4YQBUt0m6ALadE9XV56hV8BgJWDmmTPY758iIJjfQKt2nYwoUrPk0LXRXcB/yIj82T1/Ixfdpdk68LwIB0A==
+  dependencies:
+    react-style-singleton "^2.2.1"
+    tslib "^2.0.0"
+
+react-remove-scroll@2.5.5:
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz#1e31a1260df08887a8a0e46d09271b52b3a37e77"
+  integrity sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==
+  dependencies:
+    react-remove-scroll-bar "^2.3.3"
+    react-style-singleton "^2.2.1"
+    tslib "^2.1.0"
+    use-callback-ref "^1.3.0"
+    use-sidecar "^1.1.2"
+
+react-style-singleton@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/react-style-singleton/-/react-style-singleton-2.2.1.tgz#f99e420492b2d8f34d38308ff660b60d0b1205b4"
+  integrity sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==
+  dependencies:
+    get-nonce "^1.0.0"
+    invariant "^2.2.4"
+    tslib "^2.0.0"
 
 react@^18:
   version "18.2.0"
@@ -4251,7 +4452,7 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.4.0, "tslib@^2.4.1 || ^1.9.3", tslib@^2.5.0, tslib@^2.6.0:
+tslib@^2.0.0, tslib@^2.1.0, tslib@^2.4.0, "tslib@^2.4.1 || ^1.9.3", tslib@^2.5.0, tslib@^2.6.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
@@ -4388,6 +4589,21 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+use-callback-ref@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.3.0.tgz#772199899b9c9a50526fedc4993fc7fa1f7e32d5"
+  integrity sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==
+  dependencies:
+    tslib "^2.0.0"
+
+use-sidecar@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.1.2.tgz#2f43126ba2d7d7e117aa5855e5d8f0276dfe73c2"
+  integrity sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==
+  dependencies:
+    detect-node-es "^1.1.0"
+    tslib "^2.0.0"
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #68 

## ✅ 작업 내용

- 라우트에 따른 타이틀 내용물 전환 기능 구현

## 📝 참고 자료

- [useSeletecedLayoutSegments()](https://nextjs.org/docs/app/api-reference/functions/use-selected-layout-segments)

## ♾️ 기타

- 논의되었으나 이 브랜치에서 다루지 못한 라우트 변경사항(detail -> match) 추후 수정 필요
- 훕치치 로고 아이콘 IconMap에 추가 필요
