### PR TITLE
[CHORE] api 변경에 따른 타입 및 관련 컴포넌트 변경

### DIFF
--- a/src/components/common/Game/index.ts
+++ b/src/components/common/Game/index.ts
@@ -1,10 +1,10 @@
-import GameWrapper from './GameWrapper';
-import Label from './Label';
-import Score from './Score';
-import Status from './Status';
-import Team from './Team';
+import GameWrapper from './pieces/GameWrapper';
+import Label from './pieces/Label';
+import Score from './pieces/Score';
+import Status from './pieces/Status';
+import Team from './pieces/Team';
 
-export const Game = Object.assign(GameWrapper, {
+export const GameBanner = Object.assign(GameWrapper, {
   Label,
   Score,
   Status,

--- a/src/components/common/Game/pieces/GameWrapper.tsx
+++ b/src/components/common/Game/pieces/GameWrapper.tsx
@@ -8,9 +8,7 @@ type GameProps = GameDetailType & {
   className?: string;
 };
 
-export const GameContext = createContext<null | GameDetailType>(
-  {} as GameDetailType,
-);
+export const GameContext = createContext<GameDetailType>({} as GameDetailType);
 
 export default function GameWrapper({
   className,
@@ -19,7 +17,14 @@ export default function GameWrapper({
 }: GameProps) {
   return (
     <GameContext.Provider value={props}>
-      <div className={$(className)}>{children}</div>
+      <div
+        className={$(
+          'relative h-full min-h-[200px] justify-center rounded-xl bg-gray-1 shadow-lg',
+          className,
+        )}
+      >
+        {children}
+      </div>
     </GameContext.Provider>
   );
 }

--- a/src/components/common/Game/pieces/Label.tsx
+++ b/src/components/common/Game/pieces/Label.tsx
@@ -6,7 +6,7 @@ type LabelProps = {
 };
 
 export default function Label({ className }: LabelProps) {
-  const { name } = useGameContext();
+  const { gameName } = useGameContext();
 
-  return <div className={$(className)}>{name}</div>;
+  return <div className={$(className)}>{gameName}</div>;
 }

--- a/src/components/common/Game/pieces/Score.tsx
+++ b/src/components/common/Game/pieces/Score.tsx
@@ -7,11 +7,9 @@ type ScoreProps = {
 };
 
 export default function Score({ teamIndex, className }: ScoreProps) {
-  const { firstTeamScore, secondTeamScore } = useGameContext();
+  const { gameTeams } = useGameContext();
 
-  return (
-    <span className={$(className)}>
-      {teamIndex === 1 ? firstTeamScore : secondTeamScore}
-    </span>
-  );
+  const [targetTeam] = gameTeams.filter(team => team.gameTeamId === teamIndex);
+
+  return <span className={$('text-3xl', className)}>{targetTeam.score}</span>;
 }

--- a/src/components/common/Game/pieces/Status.tsx
+++ b/src/components/common/Game/pieces/Status.tsx
@@ -1,4 +1,3 @@
-import { GAME_STATUS } from '@/constants/gameStatus';
 import { useGameContext } from '@/hooks/useGameContext';
 import { $ } from '@/utils/core';
 
@@ -7,7 +6,7 @@ type StatusProps = {
 };
 
 export default function Status({ className }: StatusProps) {
-  const { gameStatus } = useGameContext();
+  const { gameQuarter } = useGameContext();
 
-  return <div className={$(className)}>{GAME_STATUS[gameStatus]}</div>;
+  return <div className={$('px-5', className)}>{gameQuarter}</div>;
 }

--- a/src/components/common/Game/pieces/Team.tsx
+++ b/src/components/common/Game/pieces/Team.tsx
@@ -9,19 +9,20 @@ type TeamProps = {
 };
 
 export default function Team({ teamIndex, className }: TeamProps) {
-  const { firstTeam, secondTeam } = useGameContext();
+  const { gameTeams } = useGameContext();
 
-  const targetTeamInfo = teamIndex === 1 ? firstTeam : secondTeam;
+  const targetTeamInfo = gameTeams[teamIndex - 1];
 
   return (
     <div className={$(className)}>
       <Image
-        width="100"
-        height="100"
+        width="65"
+        height="65"
         src={targetTeamInfo.logoImageUrl}
-        alt={`${targetTeamInfo.name}팀 로고`}
+        alt={`${targetTeamInfo.gameTeamName}팀 로고`}
+        className="my-5"
       />
-      <span>{targetTeamInfo.name}</span>
+      <span>{targetTeamInfo.gameTeamName}</span>
     </div>
   );
 }

--- a/src/hooks/useGameContext.ts
+++ b/src/hooks/useGameContext.ts
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
 
-import { GameContext } from '@/components/common/Game/GameWrapper';
+import { GameContext } from '@/components/common/Game/pieces/GameWrapper';
 import { GameDetailType } from '@/types/game';
 
 type GameContextType = () => GameDetailType;

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -5,22 +5,26 @@ export type GameType = {
   startTime: string;
   firstTeamScore: number;
   secondTeamScore: number;
-  gameStatus: GameStatusType;
+  gameStatus: GameQuarterType;
   statusChangedAt: string;
   firstTeam: GameTeamType;
   secondTeam: GameTeamType;
 };
 
-export interface GameDetailType extends GameType {
-  records: GameRecordType[];
-  videoId: string;
+export interface GameDetailType {
+  gameTeams: GameTeamType[];
+  startTime: string;
+  videoId: number;
+  gameQuarter: GameQuarterType;
+  gameName: string;
 }
 
-export type GameTeamType = {
-  id: number;
-  name: string;
+export interface GameTeamType {
+  gameTeamId: number;
+  gameTeamName: string;
   logoImageUrl: string;
-};
+  score: number;
+}
 
 export type GameRecordType = {
   id: number;
@@ -37,7 +41,7 @@ export type GameCommentType = {
   isBlocked: boolean;
 };
 
-export type GameStatusType =
+export type GameQuarterType =
   | 'BEFORE'
   | 'FIRST_HALF'
   | 'BREAK_TIME'

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -11,20 +11,20 @@ export type GameType = {
   secondTeam: GameTeamType;
 };
 
-export interface GameDetailType {
+export type GameDetailType = {
   gameTeams: GameTeamType[];
   startTime: string;
   videoId: number;
   gameQuarter: GameQuarterType;
   gameName: string;
-}
+};
 
-export interface GameTeamType {
+export type GameTeamType = {
   gameTeamId: number;
   gameTeamName: string;
   logoImageUrl: string;
   score: number;
-}
+};
 
 export type GameRecordType = {
   id: number;


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #72 

## ✅ 작업 내용

- api 변경에 따른 타입 변경
  - https://www.notion.so/heethehope/ae1ecab2a0f34c4d901bb2ec3237e4f8?pvs=4
- Game 컴포넌트 구조 변경
  - Game 컴포넌트에서 실제로 사용하는 파일은 `index.ts` 밖에 없음. 그래서 나머지 하위 컴포넌트들을 pieces 디렉토리에 몰아넣고 Game 디렉토리에서는 index에만 접근할 수 있도록 하였음
  - 근데 pieces라는 이름이 맘에 들지는 않음.

