### PR TITLE
[FEAT] match panel 컴포넌트 생성

### DIFF
--- a/src/api/league.ts
+++ b/src/api/league.ts
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 import { AxiosError } from 'axios';
 
-import instance from './instance';
+import instance from '.';
 
 export type LeagueType = {
   name: string;

--- a/src/app/match/[id]/page.tsx
+++ b/src/app/match/[id]/page.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-// import Link from 'next/link';
-
 import { Suspense } from 'react';
 
 import MatchBanner from '@/components/match/Banner';
@@ -41,10 +39,10 @@ export default function Match({ params }: { params: { id: string } }) {
             {selected === '라인업' && (
               <MatchLineupFetcher matchId={params.id}>
                 {([firstTeam, secondTeam]) => (
-                  <>
+                  <div className="grid grid-cols-2 py-5 [&>*:first-child>ul]:before:absolute [&>*:first-child>ul]:before:right-0 [&>*:first-child>ul]:before:h-full [&>*:first-child>ul]:before:border-l-2 [&>*:first-child>ul]:before:bg-gray-2">
                     <Lineup {...firstTeam} />
                     <Lineup {...secondTeam} />
-                  </>
+                  </div>
                 )}
               </MatchLineupFetcher>
             )}

--- a/src/app/match/[id]/page.tsx
+++ b/src/app/match/[id]/page.tsx
@@ -6,44 +6,61 @@ import { Suspense } from 'react';
 
 import MatchBanner from '@/components/match/Banner';
 import Cheer from '@/components/match/Cheer';
+import Lineup from '@/components/match/LineupList';
 import Panel from '@/components/match/Panel';
 import RecordList from '@/components/match/RecordList';
 import MatchByIdFetcher from '@/queries/useMatchById/Fetcher';
 import MatchCheerByIdFetcher from '@/queries/useMatchCheerById/Fetcher';
+import MatchLineupFetcher from '@/queries/useMatchLineupById/Fetcher';
 import MatchTimelineFetcher from '@/queries/useMatchTimelineById/Fetcher';
 
 export default function Match({ params }: { params: { id: string } }) {
-  const switchCase = {
-    라인업: <div>라인업</div>,
-    응원댓글: <div>응원댓글</div>,
-    경기영상: <div>경기영상</div>,
-    타임라인: (
-      <Suspense fallback={<div>타임라인 로딩 중..</div>}>
-        <MatchTimelineFetcher matchId={params.id}>
-          {([firstHalf, secondHalf]) => (
-            <div className="overflow-y-auto p-5">
-              <RecordList {...firstHalf} />
-              <RecordList {...secondHalf} />
-            </div>
-          )}
-        </MatchTimelineFetcher>
-      </Suspense>
-    ),
-  };
+  const options = [
+    { label: '라인업' },
+    { label: '응원댓글' },
+    { label: '경기영상' },
+    { label: '타임라인' },
+  ];
 
   return (
     <section>
-      <Suspense fallback={<div>배너 로딩 중...</div>}>
+      <Suspense fallback={<div>배너 로딩중...</div>}>
         <MatchByIdFetcher matchId={params.id}>
           {data => <MatchBanner {...data} />}
         </MatchByIdFetcher>
       </Suspense>
-      <Suspense fallback={<div>응원 로딩 중...</div>}>
+      <Suspense fallback={<div>응원 로딩중...</div>}>
         <MatchCheerByIdFetcher matchId={params.id}>
           {data => <Cheer cheers={data} />}
         </MatchCheerByIdFetcher>
       </Suspense>
-      <Panel switchCase={switchCase} />
+
+      <Panel options={options} defaultValue="라인업">
+        {({ selected }) => (
+          <Suspense fallback={<div>로딩중...</div>}>
+            {selected === '라인업' && (
+              <MatchLineupFetcher matchId={params.id}>
+                {([firstTeam, secondTeam]) => (
+                  <>
+                    <Lineup {...firstTeam} />
+                    <Lineup {...secondTeam} />
+                  </>
+                )}
+              </MatchLineupFetcher>
+            )}
+            {selected === '타임라인' && (
+              <MatchTimelineFetcher matchId={params.id}>
+                {([firstHalf, secondHalf]) => (
+                  <div className="overflow-y-auto p-5">
+                    <RecordList {...firstHalf} />
+                    <RecordList {...secondHalf} />
+                  </div>
+                )}
+              </MatchTimelineFetcher>
+            )}
+          </Suspense>
+        )}
+      </Panel>
     </section>
   );
 }

--- a/src/app/match/[id]/page.tsx
+++ b/src/app/match/[id]/page.tsx
@@ -6,13 +6,31 @@ import { Suspense } from 'react';
 
 import MatchBanner from '@/components/match/Banner';
 import Cheer from '@/components/match/Cheer';
-// import CommentList from '@/components/detail/CommentList';
-// import GameInfo from '@/components/detail/GameInfo';
-// import GameTimeline from '@/components/detail/GameTimeline';
+import Panel from '@/components/match/Panel';
+import RecordList from '@/components/match/RecordList';
 import MatchByIdFetcher from '@/queries/useMatchById/Fetcher';
 import MatchCheerByIdFetcher from '@/queries/useMatchCheerById/Fetcher';
+import MatchTimelineFetcher from '@/queries/useMatchTimelineById/Fetcher';
 
 export default function Match({ params }: { params: { id: string } }) {
+  const switchCase = {
+    라인업: <div>라인업</div>,
+    응원댓글: <div>응원댓글</div>,
+    경기영상: <div>경기영상</div>,
+    타임라인: (
+      <Suspense fallback={<div>타임라인 로딩 중..</div>}>
+        <MatchTimelineFetcher matchId={params.id}>
+          {([firstHalf, secondHalf]) => (
+            <div className="overflow-y-auto p-5">
+              <RecordList {...firstHalf} />
+              <RecordList {...secondHalf} />
+            </div>
+          )}
+        </MatchTimelineFetcher>
+      </Suspense>
+    ),
+  };
+
   return (
     <section>
       <Suspense fallback={<div>배너 로딩 중...</div>}>
@@ -25,6 +43,7 @@ export default function Match({ params }: { params: { id: string } }) {
           {data => <Cheer cheers={data} />}
         </MatchCheerByIdFetcher>
       </Suspense>
+      <Panel switchCase={switchCase} />
     </section>
   );
 }

--- a/src/app/match/[id]/page.tsx
+++ b/src/app/match/[id]/page.tsx
@@ -7,6 +7,7 @@ import Cheer from '@/components/match/Cheer';
 import Lineup from '@/components/match/LineupList';
 import Panel from '@/components/match/Panel';
 import RecordList from '@/components/match/RecordList';
+import Video from '@/components/match/Video';
 import MatchByIdFetcher from '@/queries/useMatchById/Fetcher';
 import MatchCheerByIdFetcher from '@/queries/useMatchCheerById/Fetcher';
 import MatchLineupFetcher from '@/queries/useMatchLineupById/Fetcher';
@@ -55,6 +56,12 @@ export default function Match({ params }: { params: { id: string } }) {
                   </div>
                 )}
               </MatchTimelineFetcher>
+            )}
+            {selected === '경기영상' && (
+              <div className="overflow-y-auto p-5">
+                {/* // TODO VideoId API 업데이트 시 ID를 받아와서 주입하는 형태로 수정 */}
+                <Video />
+              </div>
             )}
           </Suspense>
         )}

--- a/src/components/common/Dropdown/index.tsx
+++ b/src/components/common/Dropdown/index.tsx
@@ -1,0 +1,8 @@
+import Item from './units/Item';
+import Menu from './units/Menu';
+import DropdownWrapper from './units/Wrapper';
+
+export const Dropdown = Object.assign(DropdownWrapper, {
+  Menu,
+  Item,
+});

--- a/src/components/common/Dropdown/units/Item.tsx
+++ b/src/components/common/Dropdown/units/Item.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { ComponentProps, MouseEvent } from 'react';
+
+interface DropdownItemProps extends ComponentProps<'button'> {
+  onClick: (e: MouseEvent<HTMLButtonElement>) => void;
+}
+
+export default function Item({ children, ...props }: DropdownItemProps) {
+  return <button {...props}>{children}</button>;
+}

--- a/src/components/common/Dropdown/units/Menu.tsx
+++ b/src/components/common/Dropdown/units/Menu.tsx
@@ -1,0 +1,15 @@
+import { ComponentProps } from 'react';
+
+import { $ } from '@/utils/core';
+
+export default function Menu({
+  className,
+  children,
+  ...props
+}: ComponentProps<'div'>) {
+  return (
+    <div className={$('flex items-center', className)} {...props}>
+      {children}
+    </div>
+  );
+}

--- a/src/components/common/Dropdown/units/Wrapper.tsx
+++ b/src/components/common/Dropdown/units/Wrapper.tsx
@@ -1,0 +1,23 @@
+import { ComponentProps, createContext } from 'react';
+
+interface DropdownProps extends DropdownContextType, ComponentProps<'div'> {}
+
+type DropdownContextType = {
+  label?: string;
+};
+
+export const DropdownContext = createContext<DropdownContextType>({
+  label: '',
+});
+
+export default function DropdownWrapper({
+  className,
+  children,
+  ...props
+}: DropdownProps) {
+  return (
+    <DropdownContext.Provider value={{ ...props }}>
+      <div className={className}>{children}</div>
+    </DropdownContext.Provider>
+  );
+}

--- a/src/components/match/LineupItem/index.tsx
+++ b/src/components/match/LineupItem/index.tsx
@@ -1,0 +1,18 @@
+import { MatchPlayerType } from '@/types/match';
+
+export default function LineupItem({
+  playerName,
+  description,
+}: MatchPlayerType) {
+  return (
+    <li
+      className="mb-2 grid items-center gap-4"
+      style={{ gridTemplateColumns: 'minmax(0, 30px) 1fr' }}
+    >
+      <span className="flex aspect-square items-center justify-center rounded-full bg-secondary leading-relaxed text-primary">
+        {description}
+      </span>
+      <span className="text-gray-5">{playerName}</span>
+    </li>
+  );
+}

--- a/src/components/match/LineupList/index.tsx
+++ b/src/components/match/LineupList/index.tsx
@@ -1,0 +1,16 @@
+import { MatchLineupType } from '@/types/match';
+
+import LineupItem from '../LineupItem';
+
+export default function Lineup({ teamName, gameTeamPlayers }: MatchLineupType) {
+  return (
+    <div>
+      <div className="mb-3 px-4 text-primary">{teamName}</div>
+      <ul className="relative px-4">
+        {gameTeamPlayers.map((player, idx) => (
+          <LineupItem key={player.playerName + idx} {...player} />
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/match/Panel/index.tsx
+++ b/src/components/match/Panel/index.tsx
@@ -1,0 +1,44 @@
+import { MouseEvent, ReactNode, useState } from 'react';
+
+import { Dropdown } from '@/components/common/Dropdown';
+import { $ } from '@/utils/core';
+
+type PanelProps = {
+  switchCase: { [key: string]: ReactNode };
+};
+
+export default function Panel({ switchCase }: PanelProps) {
+  const options = Object.keys(switchCase).map(option => ({ label: option }));
+  const [selected, setSelected] = useState(options[0].label ?? '');
+
+  const handleClickItem = (e: MouseEvent<HTMLButtonElement>) => {
+    const selectedValue = (e.target as Element).textContent;
+
+    if (!selectedValue) return;
+    if (selected === selectedValue) return;
+
+    setSelected(selectedValue);
+  };
+
+  return (
+    <div>
+      <Dropdown className="relative rounded-xl border-2  border-gray-2">
+        <Dropdown.Menu className="grid w-full grid-cols-4 rounded-lg bg-gray-2 text-gray-4">
+          {options.map(option => (
+            <Dropdown.Item
+              onClick={handleClickItem}
+              key={option.label}
+              className={$(
+                'rounded-xl py-3',
+                selected === option.label ? 'bg-secondary text-primary' : '',
+              )}
+            >
+              {option.label}
+            </Dropdown.Item>
+          ))}
+        </Dropdown.Menu>
+        {switchCase[selected]}
+      </Dropdown>
+    </div>
+  );
+}

--- a/src/components/match/Panel/index.tsx
+++ b/src/components/match/Panel/index.tsx
@@ -4,12 +4,13 @@ import { Dropdown } from '@/components/common/Dropdown';
 import { $ } from '@/utils/core';
 
 type PanelProps = {
-  switchCase: { [key: string]: ReactNode };
+  options: Array<{ label: string }>;
+  children: ({ selected }: { selected: string }) => ReactNode;
+  defaultValue: string;
 };
 
-export default function Panel({ switchCase }: PanelProps) {
-  const options = Object.keys(switchCase).map(option => ({ label: option }));
-  const [selected, setSelected] = useState(options[0].label ?? '');
+export default function Panel({ defaultValue, options, children }: PanelProps) {
+  const [selected, setSelected] = useState(defaultValue);
 
   const handleClickItem = (e: MouseEvent<HTMLButtonElement>) => {
     const selectedValue = (e.target as Element).textContent;
@@ -37,7 +38,7 @@ export default function Panel({ switchCase }: PanelProps) {
             </Dropdown.Item>
           ))}
         </Dropdown.Menu>
-        {switchCase[selected]}
+        {children({ selected })}
       </Dropdown>
     </div>
   );

--- a/src/components/match/RecordItem/index.tsx
+++ b/src/components/match/RecordItem/index.tsx
@@ -1,0 +1,18 @@
+import { MatchRecordsType } from '@/types/match';
+
+export default function RecordItem({
+  playerName,
+  score,
+  scoredAt,
+  teamName,
+}: MatchRecordsType) {
+  return (
+    <li className="relative mb-3 ms-4">
+      <time className="absolute -left-1/2">{scoredAt}</time>
+      <span>[ {teamName} ] </span>
+      <span>
+        {playerName} 선수 {score}점 득점 🎉
+      </span>
+    </li>
+  );
+}

--- a/src/components/match/RecordList/index.tsx
+++ b/src/components/match/RecordList/index.tsx
@@ -1,0 +1,16 @@
+import { MatchTimelineType } from '@/types/match';
+
+import RecordItem from '../RecordItem';
+
+export default function RecordList({ gameQuater, records }: MatchTimelineType) {
+  return (
+    <>
+      <div className="mb-3 text-primary">{gameQuater}</div>
+      <ol className="ms-5 border-s">
+        {records.map(record => (
+          <RecordItem key={record.scoredAt} {...record} />
+        ))}
+      </ol>
+    </>
+  );
+}

--- a/src/components/match/RecordList/index.tsx
+++ b/src/components/match/RecordList/index.tsx
@@ -2,10 +2,13 @@ import { MatchTimelineType } from '@/types/match';
 
 import RecordItem from '../RecordItem';
 
-export default function RecordList({ gameQuater, records }: MatchTimelineType) {
+export default function RecordList({
+  gameQuarter,
+  records,
+}: MatchTimelineType) {
   return (
     <>
-      <div className="mb-3 text-primary">{gameQuater}</div>
+      <div className="mb-3 text-primary">{gameQuarter}</div>
       <ol className="ms-5 border-s">
         {records.map(record => (
           <RecordItem key={record.scoredAt} {...record} />

--- a/src/components/match/Video/index.tsx
+++ b/src/components/match/Video/index.tsx
@@ -1,0 +1,11 @@
+export default function Video() {
+  return (
+    <iframe
+      className="aspect-video w-full"
+      src="https://www.youtube.com/embed/rLtgA5qQryM?si=w-py0FFuiHisx-k-"
+      title="Match Video"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+      allowFullScreen
+    ></iframe>
+  );
+}

--- a/src/queries/useMatchLineupById/Fetcher.tsx
+++ b/src/queries/useMatchLineupById/Fetcher.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from 'react';
+
+import { MatchLineupType } from '@/types/match';
+
+import { useMatchLineupById } from './query';
+
+type MatchLineupFetcherProps = {
+  matchId: string;
+  children: (data: MatchLineupType[]) => ReactNode;
+};
+
+export default function MatchLineupFetcher({
+  matchId,
+  children,
+}: MatchLineupFetcherProps) {
+  const { lineup, error } = useMatchLineupById(matchId);
+
+  if (error) throw error;
+
+  return children(lineup);
+}

--- a/src/queries/useMatchLineupById/query.ts
+++ b/src/queries/useMatchLineupById/query.ts
@@ -1,0 +1,15 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+import { getMatchLineupById } from '@/api/match';
+
+export const useMatchLineupById = (matchId: string) => {
+  const { data, error } = useSuspenseQuery({
+    queryKey: ['match-lineup', matchId],
+    queryFn: () => getMatchLineupById(matchId),
+  });
+
+  return {
+    lineup: data,
+    error,
+  };
+};

--- a/src/queries/useMatchTimelineById/Fetcher.tsx
+++ b/src/queries/useMatchTimelineById/Fetcher.tsx
@@ -10,7 +10,7 @@ type MatchRecordsType = {
 };
 
 type MatchTimelineType = {
-  gameQuater: string;
+  gameQuarter: string;
   records: MatchRecordsType[];
 };
 
@@ -18,43 +18,6 @@ type MatchTimelineFetcherProps = {
   matchId: string;
   children: (data: MatchTimelineType[]) => ReactNode;
 };
-
-const DUMMY = [
-  {
-    gameQuater: '후반전',
-    records: [
-      {
-        scoredAt: 26,
-        playerName: '진승희',
-        teamName: '팀 A',
-        score: 1,
-      },
-      {
-        scoredAt: 25,
-        playerName: '이동규',
-        teamName: '팀 B',
-        score: 1,
-      },
-    ],
-  },
-  {
-    gameQuater: '전반전',
-    records: [
-      {
-        scoredAt: 26,
-        playerName: '진승희',
-        teamName: '팀 A',
-        score: 1,
-      },
-      {
-        scoredAt: 25,
-        playerName: '이동규',
-        teamName: '팀 B',
-        score: 1,
-      },
-    ],
-  },
-];
 
 export default function MatchTimelineFetcher({
   matchId,
@@ -64,5 +27,5 @@ export default function MatchTimelineFetcher({
 
   if (error) throw error;
 
-  return children(timeline.length === 0 ? DUMMY : timeline);
+  return children(timeline);
 }

--- a/src/queries/useMatchTimelineById/Fetcher.tsx
+++ b/src/queries/useMatchTimelineById/Fetcher.tsx
@@ -1,0 +1,68 @@
+import { ReactNode } from 'react';
+
+import { useMatchTimelineById } from './query';
+
+type MatchRecordsType = {
+  scoredAt: number;
+  playerName: string;
+  teamName: string;
+  score: number;
+};
+
+type MatchTimelineType = {
+  gameQuater: string;
+  records: MatchRecordsType[];
+};
+
+type MatchTimelineFetcherProps = {
+  matchId: string;
+  children: (data: MatchTimelineType[]) => ReactNode;
+};
+
+const DUMMY = [
+  {
+    gameQuater: '후반전',
+    records: [
+      {
+        scoredAt: 26,
+        playerName: '진승희',
+        teamName: '팀 A',
+        score: 1,
+      },
+      {
+        scoredAt: 25,
+        playerName: '이동규',
+        teamName: '팀 B',
+        score: 1,
+      },
+    ],
+  },
+  {
+    gameQuater: '전반전',
+    records: [
+      {
+        scoredAt: 26,
+        playerName: '진승희',
+        teamName: '팀 A',
+        score: 1,
+      },
+      {
+        scoredAt: 25,
+        playerName: '이동규',
+        teamName: '팀 B',
+        score: 1,
+      },
+    ],
+  },
+];
+
+export default function MatchTimelineFetcher({
+  matchId,
+  children,
+}: MatchTimelineFetcherProps) {
+  const { timeline, error } = useMatchTimelineById(matchId);
+
+  if (error) throw error;
+
+  return children(timeline.length === 0 ? DUMMY : timeline);
+}

--- a/src/queries/useMatchTimelineById/query.ts
+++ b/src/queries/useMatchTimelineById/query.ts
@@ -1,0 +1,17 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+import { getMatchTimelineById } from '@/api/match';
+
+export const useMatchTimelineById = (matchId: string) => {
+  const { data, error } = useSuspenseQuery({
+    queryKey: ['match-timeline', matchId],
+    queryFn: () => getMatchTimelineById(matchId),
+  });
+
+  if (error) throw error;
+
+  return {
+    timeline: data,
+    error,
+  };
+};

--- a/src/types/match.ts
+++ b/src/types/match.ts
@@ -39,7 +39,7 @@ export type MatchRecordsType = {
 };
 
 export type MatchTimelineType = {
-  gameQuater: MatchQuarterType;
+  gameQuarter: MatchQuarterType;
   records: MatchRecordsType[];
 };
 


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #74
- #51

## ✅ 작업 내용

- Dropdown 컴포넌트를 생성했습니다.
  - 다양한 곳에서 활용될 수 있는 합성 컴포넌트로, 현재 경기 상세 정보의 Panel에서 사용하고 있습니다.
  - 추후 Sidebar를 해당 컴포넌트로 리팩토링하면 좋을 것 같습니다.
  - 메인 페이지에서 카테고리 및 경기 상태 선택 시에도 활용할 수 있을 것 같습니다.
- Panel 컴포넌트 생성
  - selected 상태를 보유하고 있고, 전달 받을 children에 selected를 담아 내보냅니다.
  - 컴포넌트 외부에서는 selected를 뽑아서 원하는 컴포넌트를 렌더링 할 수 있습니다.
  - `selected === '경기영상'`처럼 그냥 문자열로 비교하고 있는데, 이를 별도로 상수화 하여 유지보수 하기 좋게 만들면 좋을 것 같습니다.
- 경기 타임라인 컴포넌트, 라인업 컴포넌트, 유튜브 영상 컴포넌트를 생성했습니다.
  - 관련한 api 및 query hooks 역시 추가해뒀습니다.
  - ( RecordList / RecordItem ), ( LineupList / LineupItem ) 두 컴포넌트 조합이 스타일만 다를 뿐 구조는 동일한 것처럼 보입니다. 그래서 추후 시간이 나면 공통 List, Item으로 구분해볼 수 있을 것 같습니다.
  - Video 컴포넌트는 정해진 주소를 등록해뒀는데, 추후 Video API가 개발되면 props를 주입해주면 될 것 같습니다.
- 댓글 API는 아직 구현이 되어 있지 않아서 일단은 제외하고 올렸습니다.

## ♾️ 기타

- 각 컴포넌트마다 스켈레톤 컴포넌트 생성
- 공용으로 사용할 수 있는 Loader 컴포넌트 생성
- Error Boundary를 생성하고 이를 Suspense와 결합하여 Async Boundary 생성해서 일괄적으로 사용할 수 있도록 하는 게 좋아보임
  - Error boundary는 React-ErrorBoundary라는 라이브러리가 있어서 사용하면 좋을 것 같음
- Fetcher 컴포넌트의 구조가 모두 동일하기 때문에 이를 추상화 할 수 있을 것 같음. 시간이 나면 해보면 될 듯
