### PR TITLE
[FEAT] Match List 컴포넌트 생성

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -2,7 +2,6 @@ import * as Sentry from '@sentry/nextjs';
 import { AxiosError } from 'axios';
 
 import { AuthPayload, AuthType } from '@/types/auth';
-import { MatchQuarterType } from '@/types/match';
 
 import { adminInstance } from '.';
 
@@ -27,9 +26,6 @@ export const postLogin = async (body: AuthPayload) => {
   }
 };
 
-export const postGameStatus = async (
-  id: number,
-  gameStatus: MatchQuarterType,
-) => {
+export const postGameStatus = async (id: number, gameStatus: string) => {
   adminInstance.post(`/manage/game/statustype/${id}/`, { gameStatus });
 };

--- a/src/api/match.ts
+++ b/src/api/match.ts
@@ -1,15 +1,34 @@
 import {
   MatchCheerType,
   MatchCommentType,
-  MatchDetailType,
   MatchLineupType,
+  MatchListType,
   MatchTimelineType,
+  MatchType,
 } from '@/types/match';
+import { convertObjectToQueryString } from '@/utils/queryString';
 
 import instance from '.';
 
+export type MatchListParams = {
+  sportsId: number | number[];
+  status: 'playing' | 'scheduled' | 'finished';
+  leagueId: number;
+};
+
+export const getMatchList = async (params: MatchListParams) => {
+  const queryString = convertObjectToQueryString<
+    keyof MatchListParams,
+    MatchListParams[keyof MatchListParams]
+  >(params);
+
+  const { data } = await instance.get<MatchListType[]>(`games?${queryString}`);
+
+  return data;
+};
+
 export const getMatchById = async (gameId: string) => {
-  const { data } = await instance.get<MatchDetailType>(`/games/${gameId}`);
+  const { data } = await instance.get<MatchType>(`/games/${gameId}`);
 
   return data;
 };

--- a/src/api/match.ts
+++ b/src/api/match.ts
@@ -5,6 +5,7 @@ import {
   MatchListType,
   MatchTimelineType,
   MatchType,
+  MatchVideoType,
 } from '@/types/match';
 import { convertObjectToQueryString } from '@/utils/queryString';
 
@@ -60,6 +61,14 @@ export const getMatchTimelineById = async (matchId: string) => {
 export const getMatchLineupById = async (matchId: string) => {
   const { data } = await instance.get<MatchLineupType[]>(
     `/games/${matchId}/lineup`,
+  );
+
+  return data;
+};
+
+export const getMatchVideoById = async (matchId: string) => {
+  const { data } = await instance.get<MatchVideoType>(
+    `/games/${matchId}/video`,
   );
 
   return data;

--- a/src/app/match/[id]/page.tsx
+++ b/src/app/match/[id]/page.tsx
@@ -12,6 +12,7 @@ import MatchByIdFetcher from '@/queries/useMatchById/Fetcher';
 import MatchCheerByIdFetcher from '@/queries/useMatchCheerById/Fetcher';
 import MatchLineupFetcher from '@/queries/useMatchLineupById/Fetcher';
 import MatchTimelineFetcher from '@/queries/useMatchTimelineById/Fetcher';
+import MatchVideoFetcher from '@/queries/useMatchVideoById/Fetcher';
 
 export default function Match({ params }: { params: { id: string } }) {
   const options = [
@@ -58,10 +59,13 @@ export default function Match({ params }: { params: { id: string } }) {
               </MatchTimelineFetcher>
             )}
             {selected === '경기영상' && (
-              <div className="overflow-y-auto p-5">
-                {/* // TODO VideoId API 업데이트 시 ID를 받아와서 주입하는 형태로 수정 */}
-                <Video />
-              </div>
+              <MatchVideoFetcher matchId={params.id}>
+                {data => (
+                  <div className="overflow-y-auto p-5">
+                    <Video {...data} />
+                  </div>
+                )}
+              </MatchVideoFetcher>
             )}
           </Suspense>
         )}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,22 +1,21 @@
 'use client';
 
+import { Suspense } from 'react';
+
+import MatchList from '@/components/match/MatchList';
+import MatchListFetcher from '@/queries/useMatchList/Fetcher';
+
 export default function Home() {
   return (
     <main className="flex w-full flex-col gap-3">
       <p className="my-2 text-center text-xl font-bold">매치</p>
       <div className="flex flex-col gap-8">
-        {/**DUMMY_GAME.map(game => (
-          <Game records={[]} videoId={''} key={game.id} {...game}>
-            <Game.Label className="mb-2 border-b-[1px] border-black pb-1" />
-            <div className="flex items-center">
-              <Game.Team teamIndex={1} />
-              <Game.Score teamIndex={1} />
-              <Game.Status />
-              <Game.Score teamIndex={2} />
-              <Game.Team teamIndex={2} />
-            </div>
-          </Game>
-        ))*/}
+        <Suspense fallback={<div>MatchList 로딩중...</div>}>
+          {/* // TODO sportsId, leagueId, status 상태를 동적 주입 */}
+          <MatchListFetcher sportsId={1} leagueId={1} status="playing">
+            {data => <MatchList matchList={data} />}
+          </MatchListFetcher>
+        </Suspense>
       </div>
     </main>
   );

--- a/src/components/common/MatchCard/index.ts
+++ b/src/components/common/MatchCard/index.ts
@@ -1,3 +1,4 @@
+import Background from './pieces/Background';
 import Label from './pieces/Label';
 import Score from './pieces/Score';
 import Status from './pieces/Status';
@@ -9,4 +10,5 @@ export const MatchCard = Object.assign(MatchWrapper, {
   Score,
   Status,
   Team,
+  Background,
 });

--- a/src/components/common/MatchCard/pieces/Background.tsx
+++ b/src/components/common/MatchCard/pieces/Background.tsx
@@ -1,0 +1,21 @@
+import { ComponentProps } from 'react';
+
+import { Icon } from '@/components/common/Icon';
+import { $ } from '@/utils/core';
+
+interface LabelProps extends ComponentProps<'svg'> {
+  className?: string;
+}
+
+export default function Label({ className, ...props }: LabelProps) {
+  return (
+    <Icon
+      iconName="logo"
+      className={$(
+        'absolute left-1/2 h-[200px] -translate-x-1/2 fill-primary',
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/src/components/common/MatchCard/pieces/Label.tsx
+++ b/src/components/common/MatchCard/pieces/Label.tsx
@@ -6,7 +6,13 @@ type LabelProps = {
 };
 
 export default function Label({ className }: LabelProps) {
-  const { gameName } = useMatchCardContext();
+  const { gameName, sportsName, startTime } = useMatchCardContext();
 
-  return <div className={$(className)}>{gameName}</div>;
+  return (
+    <div className={$(className)}>
+      {startTime && <div>{startTime}</div>}
+      {sportsName && <div className="text-center">{sportsName}</div>}
+      {gameName && <div className="text-right">{gameName}</div>}
+    </div>
+  );
 }

--- a/src/components/common/MatchCard/pieces/Wrapper.tsx
+++ b/src/components/common/MatchCard/pieces/Wrapper.tsx
@@ -1,6 +1,5 @@
 import { createContext, ReactNode } from 'react';
 
-import { Icon } from '@/components/common/Icon';
 import { MatchType } from '@/types/match';
 import { $ } from '@/utils/core';
 
@@ -18,19 +17,7 @@ export default function MatchWrapper({
 }: MatchProps) {
   return (
     <MatchContext.Provider value={props}>
-      <div
-        className={$(
-          'relative h-full min-h-[200px] justify-center rounded-xl bg-gray-1  shadow-lg',
-          className,
-        )}
-      >
-        <Icon
-          viewBox="-3 120 100 50"
-          width={150}
-          height={200}
-          iconName="logo"
-          className="absolute left-1/2 h-full -translate-x-1/2 fill-primary"
-        />
+      <div className={$('relative h-full justify-center', className)}>
         {children}
       </div>
     </MatchContext.Provider>

--- a/src/components/common/MatchCard/pieces/Wrapper.tsx
+++ b/src/components/common/MatchCard/pieces/Wrapper.tsx
@@ -1,17 +1,15 @@
 import { createContext, ReactNode } from 'react';
 
 import { Icon } from '@/components/common/Icon';
-import { MatchDetailType } from '@/types/match';
+import { MatchType } from '@/types/match';
 import { $ } from '@/utils/core';
 
-type MatchProps = MatchDetailType & {
+type MatchProps = MatchType & {
   children: ReactNode;
   className?: string;
 };
 
-export const MatchContext = createContext<MatchDetailType>(
-  {} as MatchDetailType,
-);
+export const MatchContext = createContext<MatchType>({} as MatchType);
 
 export default function MatchWrapper({
   className,

--- a/src/components/match/Banner/index.tsx
+++ b/src/components/match/Banner/index.tsx
@@ -1,7 +1,7 @@
 import { MatchCard } from '@/components/common/MatchCard';
-import { MatchDetailType } from '@/types/match';
+import { MatchType } from '@/types/match';
 
-export default function MatchBanner(props: MatchDetailType) {
+export default function MatchBanner(props: MatchType) {
   return (
     <MatchCard {...props} className="flex flex-col">
       <MatchCard.Label className="absolute left-2 top-2" />

--- a/src/components/match/Banner/index.tsx
+++ b/src/components/match/Banner/index.tsx
@@ -4,8 +4,14 @@ import { MatchType } from '@/types/match';
 export default function MatchBanner(props: MatchType) {
   return (
     <MatchCard {...props} className="flex flex-col">
-      <MatchCard.Label className="absolute left-2 top-2" />
-      <div className="flex h-full items-center justify-around">
+      <MatchCard.Label className="absolute top-2 flex w-full justify-between px-2" />
+      <div className="flex h-full min-h-[200px] items-center justify-around rounded-xl bg-gray-1 shadow-lg">
+        <MatchCard.Background
+          viewBox="-3 120 100 50"
+          width={150}
+          height={200}
+          className="h-[200px]"
+        />
         <MatchCard.Team teamIndex={1} className="flex flex-col items-center" />
         <MatchCard.Score teamIndex={1} />
         <MatchCard.Status />

--- a/src/components/match/MatchList/index.tsx
+++ b/src/components/match/MatchList/index.tsx
@@ -1,0 +1,44 @@
+import Link from 'next/link';
+
+import { MatchCard } from '@/components/common/MatchCard';
+import { MatchListType } from '@/types/match';
+
+export default function MatchList({
+  matchList,
+}: {
+  matchList: MatchListType[];
+}) {
+  return (
+    <ul>
+      {matchList.map(({ gameId, ...match }) => (
+        <li key={gameId}>
+          <Link href={`match/${gameId}`}>
+            <MatchCard {...match} className="mb-14 flex flex-col">
+              <MatchCard.Label className="mb-2 grid w-full grid-cols-3 border-b-2 border-b-gray-5 px-1 pb-1" />
+              <div className="flex h-full min-h-[180px] items-center justify-around rounded-xl bg-gray-1 shadow-lg">
+                <MatchCard.Background
+                  viewBox="-13 117 120 50"
+                  width={150}
+                  height={170}
+                  className="h-[180px]"
+                />
+
+                <MatchCard.Team
+                  teamIndex={1}
+                  className="flex flex-col items-center"
+                />
+                <MatchCard.Score teamIndex={1} />
+                <MatchCard.Status />
+                <MatchCard.Score teamIndex={2} />
+                <MatchCard.Team
+                  teamIndex={2}
+                  className="flex flex-col items-center"
+                />
+              </div>
+            </MatchCard>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/match/Video/index.tsx
+++ b/src/components/match/Video/index.tsx
@@ -1,11 +1,20 @@
-export default function Video() {
+import { ComponentProps } from 'react';
+
+import { YOUTUBE_VIDEO_BASE_SRC } from '@/constants/videoSrc';
+
+interface VideoProps extends ComponentProps<'iframe'> {
+  videoId: string;
+}
+
+export default function Video({ videoId, ...props }: VideoProps) {
   return (
     <iframe
       className="aspect-video w-full"
-      src="https://www.youtube.com/embed/rLtgA5qQryM?si=w-py0FFuiHisx-k-"
+      src={`${YOUTUBE_VIDEO_BASE_SRC}/${videoId}`}
       title="Match Video"
       allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
       allowFullScreen
+      {...props}
     ></iframe>
   );
 }

--- a/src/constants/videoSrc.ts
+++ b/src/constants/videoSrc.ts
@@ -1,0 +1,1 @@
+export const YOUTUBE_VIDEO_BASE_SRC = 'https://www.youtube.com/embed';

--- a/src/hooks/useMatchCardContext.ts
+++ b/src/hooks/useMatchCardContext.ts
@@ -1,9 +1,9 @@
 import { useContext } from 'react';
 
 import { MatchContext } from '@/components/common/MatchCard/pieces/Wrapper';
-import { MatchDetailType } from '@/types/match';
+import { MatchType } from '@/types/match';
 
-type MatchCardContextType = () => MatchDetailType;
+type MatchCardContextType = () => MatchType;
 
 export const useMatchCardContext: MatchCardContextType = () => {
   const matchContext = useContext(MatchContext);

--- a/src/queries/useMatchById/Fetcher.tsx
+++ b/src/queries/useMatchById/Fetcher.tsx
@@ -1,12 +1,12 @@
 import { ReactNode } from 'react';
 
-import { MatchDetailType } from '@/types/match';
+import { MatchType } from '@/types/match';
 
 import useMatchById from './query';
 
 type MatchByIdFetcherProps = {
   matchId: string;
-  children: (data: MatchDetailType) => ReactNode;
+  children: (data: MatchType) => ReactNode;
 };
 
 export default function MatchByIdFetcher({

--- a/src/queries/useMatchList/Fetcher.tsx
+++ b/src/queries/useMatchList/Fetcher.tsx
@@ -1,0 +1,70 @@
+import { ReactNode } from 'react';
+
+import { MatchListParams } from '@/api/match';
+import { MatchListType } from '@/types/match';
+
+import { useMatchList } from './query';
+
+const DUMMY: MatchListType[] = [
+  {
+    gameId: 1,
+    startTime: '2023-11-07 23:00',
+    gameQuarter: '전반',
+    gameName: '4강',
+    sportsName: '축구',
+    gameTeams: [
+      {
+        gameTeamId: 1,
+        logoImageUrl:
+          'https://hufscheer-server.s3.ap-northeast-2.amazonaws.com/먹거리대회/팬돌이.png',
+        gameTeamName: '팬돌이',
+        score: 7,
+      },
+      {
+        gameTeamId: 3,
+        logoImageUrl:
+          'https://hufscheer-server.s3.ap-northeast-2.amazonaws.com/먹거리대회/요구르트.png',
+        gameTeamName: '요구르트',
+        score: 7,
+      },
+    ],
+  },
+  {
+    gameId: 2,
+    startTime: '2023-11-07 23:00',
+    gameQuarter: '전반',
+    gameName: '4강',
+    sportsName: '축구',
+    gameTeams: [
+      {
+        gameTeamId: 1,
+        logoImageUrl:
+          'https://hufscheer-server.s3.ap-northeast-2.amazonaws.com/먹거리대회/팬돌이.png',
+        gameTeamName: '팬돌이',
+        score: 7,
+      },
+      {
+        gameTeamId: 3,
+        logoImageUrl:
+          'https://hufscheer-server.s3.ap-northeast-2.amazonaws.com/먹거리대회/요구르트.png',
+        gameTeamName: '요구르트',
+        score: 7,
+      },
+    ],
+  },
+];
+
+interface MatchListFetcherProps extends MatchListParams {
+  children: (data: MatchListType[]) => ReactNode;
+}
+
+export default function MatchListFetcher({
+  children,
+  ...props
+}: MatchListFetcherProps) {
+  const { error } = useMatchList(props);
+
+  if (error) throw error;
+
+  return children(DUMMY);
+}

--- a/src/queries/useMatchList/query.ts
+++ b/src/queries/useMatchList/query.ts
@@ -1,0 +1,19 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+import { getMatchList, MatchListParams } from '@/api/match';
+
+export const useMatchList = ({
+  sportsId,
+  status,
+  leagueId,
+}: MatchListParams) => {
+  const { data, error } = useSuspenseQuery({
+    queryKey: ['match-list', sportsId, status, leagueId],
+    queryFn: () => getMatchList({ sportsId, status, leagueId }),
+  });
+
+  return {
+    matchList: data,
+    error,
+  };
+};

--- a/src/queries/useMatchTimelineById/Fetcher.tsx
+++ b/src/queries/useMatchTimelineById/Fetcher.tsx
@@ -1,18 +1,8 @@
 import { ReactNode } from 'react';
 
+import { MatchTimelineType } from '@/types/match';
+
 import { useMatchTimelineById } from './query';
-
-type MatchRecordsType = {
-  scoredAt: number;
-  playerName: string;
-  teamName: string;
-  score: number;
-};
-
-type MatchTimelineType = {
-  gameQuarter: string;
-  records: MatchRecordsType[];
-};
 
 type MatchTimelineFetcherProps = {
   matchId: string;

--- a/src/queries/useMatchTimelineById/query.ts
+++ b/src/queries/useMatchTimelineById/query.ts
@@ -8,8 +8,6 @@ export const useMatchTimelineById = (matchId: string) => {
     queryFn: () => getMatchTimelineById(matchId),
   });
 
-  if (error) throw error;
-
   return {
     timeline: data,
     error,

--- a/src/queries/useMatchVideoById/Fetcher.tsx
+++ b/src/queries/useMatchVideoById/Fetcher.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from 'react';
+
+import { MatchVideoType } from '@/types/match';
+
+import { useMatchVideoById } from './query';
+
+type MatchVideoFetcherProps = {
+  matchId: string;
+  children: (data: MatchVideoType) => ReactNode;
+};
+
+export default function MatchVideoFetcher({
+  matchId,
+  children,
+}: MatchVideoFetcherProps) {
+  const { videoId, error } = useMatchVideoById(matchId);
+
+  if (error) throw error;
+
+  return children(videoId);
+}

--- a/src/queries/useMatchVideoById/query.ts
+++ b/src/queries/useMatchVideoById/query.ts
@@ -1,0 +1,15 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+import { getMatchVideoById } from '@/api/match';
+
+export const useMatchVideoById = (matchId: string) => {
+  const { data, error } = useSuspenseQuery({
+    queryKey: ['match-video', matchId],
+    queryFn: () => getMatchVideoById(matchId),
+  });
+
+  return {
+    videoId: data,
+    error,
+  };
+};

--- a/src/types/match.ts
+++ b/src/types/match.ts
@@ -1,6 +1,5 @@
 export interface MatchListType extends MatchType {
   gameId: number;
-  sportsName: string;
 }
 
 export interface MatchType {
@@ -8,6 +7,7 @@ export interface MatchType {
   startTime: string;
   gameQuarter: string;
   gameName: string;
+  sportsName: string;
 }
 
 export type MatchTeamType = {

--- a/src/types/match.ts
+++ b/src/types/match.ts
@@ -52,3 +52,7 @@ export type MatchCommentType = {
   createdAt: string;
   isBlocked: boolean;
 };
+
+export type MatchVideoType = {
+  videoId: string;
+};

--- a/src/types/match.ts
+++ b/src/types/match.ts
@@ -1,23 +1,14 @@
-export type MatchType = {
-  id: number;
-  name: string;
+export interface MatchListType extends MatchType {
+  gameId: number;
   sportsName: string;
-  startTime: string;
-  firstTeamScore: number;
-  secondTeamScore: number;
-  gameStatus: MatchQuarterType;
-  statusChangedAt: string;
-  firstTeam: MatchTeamType;
-  secondTeam: MatchTeamType;
-};
+}
 
-export type MatchDetailType = {
+export interface MatchType {
   gameTeams: MatchTeamType[];
   startTime: string;
-  videoId: number;
-  gameQuarter: MatchQuarterType;
+  gameQuarter: string;
   gameName: string;
-};
+}
 
 export type MatchTeamType = {
   gameTeamId: number;
@@ -38,8 +29,9 @@ export type MatchRecordsType = {
   score: number;
 };
 
+// TODO 추후 회의를 통해 Quarter 타입을 특정하고 유니온 타입으로 사용할 것
 export type MatchTimelineType = {
-  gameQuarter: MatchQuarterType;
+  gameQuarter: string;
   records: MatchRecordsType[];
 };
 
@@ -60,5 +52,3 @@ export type MatchCommentType = {
   createdAt: string;
   isBlocked: boolean;
 };
-
-export type MatchQuarterType = string;

--- a/src/utils/queryString.ts
+++ b/src/utils/queryString.ts
@@ -1,0 +1,15 @@
+export const convertObjectToQueryString = <T extends string, U>(
+  params: Record<T, U>,
+) => {
+  const queryString = new URLSearchParams();
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (Array.isArray(value)) {
+      value.forEach(valueItem => queryString.append(key, valueItem));
+    } else {
+      queryString.append(key, String(value));
+    }
+  });
+
+  return queryString.toString();
+};


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #80

## ✅ 작업 내용

- match type, match list type 수정
- match card label 수정 및 background icon을 match card 하위 컴포넌트로 변환
- match list 컴포넌트 생성
  - `TODO-1`. match list call api 개발이 덜 된 관계로 `DUMMY`를 넣어뒀습니다!
  - `TODO-2`. sportsId, leagueId, status 상태를 동적 주입

## 📝 참고 자료

- 작업한 내용에 대한 부연 설명

## ♾️ 기타

- 추가로 필요한 작업 내용
