### PR TITLE
[FEAT] useFunnel hook 함수 생성

### DIFF
--- a/src/components/match/MatchList/index.tsx
+++ b/src/components/match/MatchList/index.tsx
@@ -11,9 +11,9 @@ export default function MatchList({
   return (
     <ul>
       {matchList.map(({ gameId, ...match }) => (
-        <li key={gameId}>
+        <li key={gameId} className="mb-14">
           <Link href={`match/${gameId}`}>
-            <MatchCard {...match} className="mb-14 flex flex-col">
+            <MatchCard {...match} className="flex flex-col">
               <MatchCard.Label className="mb-2 grid w-full grid-cols-3 border-b-2 border-b-gray-5 px-1 pb-1" />
               <div className="flex h-full min-h-[180px] items-center justify-around rounded-xl bg-gray-1 shadow-lg">
                 <MatchCard.Background

--- a/src/hooks/useFunnel.tsx
+++ b/src/hooks/useFunnel.tsx
@@ -1,0 +1,69 @@
+import { useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/router';
+import {
+  Children,
+  isValidElement,
+  ReactElement,
+  ReactNode,
+  useCallback,
+  useMemo,
+} from 'react';
+
+export interface FunnelProps<T extends string[]> {
+  steps: T;
+  step: T[number];
+  children: Array<ReactElement<StepProps<T>>> | ReactElement<StepProps<T>>;
+}
+
+export interface StepProps<T extends string[]> {
+  name: T[number];
+  children?: ReactNode;
+}
+
+const Funnel = <T extends string[]>({
+  steps,
+  step,
+  children,
+}: FunnelProps<T>) => {
+  const validChildren = Children.toArray(children)
+    .filter(isValidElement)
+    .filter(i =>
+      steps.includes((i.props as Partial<StepProps<T>>).name ?? ''),
+    ) as Array<ReactElement<StepProps<T>>>;
+
+  const targetStep = validChildren.find(child => child.props.name === step);
+
+  return <>{targetStep || null}</>;
+};
+
+const Step = <T extends string[]>({ children }: StepProps<T>) => {
+  return <>{children}</>;
+};
+
+export const useFunnel = <T extends string[]>(
+  steps: T,
+  defaultStep: T[number],
+) => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const setStep = useCallback(
+    (step: T[number]) => {
+      router.push({ query: { step } });
+    },
+    [router],
+  );
+
+  const FunnelComponent = useMemo(() => {
+    return Object.assign(
+      (props: Omit<FunnelProps<T>, 'step' | 'steps'>) => {
+        const step = searchParams.get('step') ?? defaultStep;
+
+        return <Funnel<T> steps={steps} step={step} {...props} />;
+      },
+      { Step },
+    );
+  }, [defaultStep, searchParams, steps]);
+
+  return [FunnelComponent, setStep] as const;
+};


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #84 

## ✅ 작업 내용

- 모바일 뷰는 데스크탑에 비해 화면이 작고, 때문에 많은 정보가 담길수록 유저는 이를 한 눈에 파악하기가 더 어렵습니다. 따라서 query string으로 페이지를 전환하여 정보를 나누고, 순차적으로 입력 받을 수 있도록 하였고, 이를 선언적으로 관리할 수 있도록 도와주는 `useFunnel` 훅 함수를 생성했습니다.

## 📝 참고 자료

- 자세한 정보는 [진유림 님의 영상](https://www.youtube.com/watch?v=NwLWX2RNVcw)을 참고했습니다.