### PR TITLE
[STYLE]: 사이드바 범위 재적용

### DIFF
--- a/src/components/common/Sidebar/index.tsx
+++ b/src/components/common/Sidebar/index.tsx
@@ -3,19 +3,24 @@
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 
-import { getAllLeagues, LeagueType } from '@/api/league';
+import { getAllLeaguesWithAuth } from '@/api/admin/league';
+import { LeagueType } from '@/types/admin/league';
 
 type SidebarProps = {
+  isSidebarOpen: boolean;
   onClickSidebar: () => void;
 };
-export default function Sidebar({ onClickSidebar }: SidebarProps) {
+export default function Sidebar({
+  isSidebarOpen,
+  onClickSidebar,
+}: SidebarProps) {
   const [menuContent, setMenuContent] = useState<LeagueType[]>([
-    { name: '전체', leagueId: 0 },
+    { name: '전체', leagueId: 0, startAt: '', endAt: '' },
   ]);
 
   useEffect(() => {
     const getLeagueData = async () => {
-      const res = await getAllLeagues();
+      const res = await getAllLeaguesWithAuth();
 
       setMenuContent(prev => [...prev, ...res]);
     };
@@ -24,31 +29,40 @@ export default function Sidebar({ onClickSidebar }: SidebarProps) {
   }, []);
 
   return (
-    <aside>
-      <div
-        className="fixed inset-0 bg-black/50"
-        onClick={onClickSidebar}
-        aria-hidden="true"
-      />
-      <div className="fixed right-0 top-0 z-40 h-screen w-64 bg-gray-1 p-5 py-8 text-gray-5">
-        <div className="my-2 text-xl font-semibold">대회 목록</div>
-        <ul className="overflow-y-auto ">
-          {menuContent.map(content => (
-            <li
-              key={content.leagueId}
-              onClick={onClickSidebar}
-              aria-hidden="true"
-            >
-              <Link
-                href={{ pathname: '/', query: { leagueId: content.leagueId } }}
-                className="flex items-center rounded-lg p-2 hover:bg-gray-2 dark:text-white dark:hover:bg-gray-5"
+    isSidebarOpen && (
+      <aside>
+        <div
+          data-state={isSidebarOpen}
+          className="absolute inset-0 z-40 h-screen bg-black/50 data-[state=false]:animate-[dialog-overlay-hide_100ms] data-[state=true]:animate-[dialog-overlay-show_100ms]"
+          onClick={onClickSidebar}
+          aria-hidden="true"
+        />
+        <div
+          data-state={isSidebarOpen}
+          className="absolute right-0 top-0 z-40 h-screen w-64 bg-gray-1 p-5 py-8 text-gray-5 data-[state=false]:animate-[menu-content-hide_100ms] data-[state=true]:animate-[menu-content-show_100ms]"
+        >
+          <div className="my-2 text-xl font-semibold">대회 목록</div>
+          <ul className="overflow-y-auto ">
+            {menuContent.map(content => (
+              <li
+                key={content.leagueId}
+                onClick={onClickSidebar}
+                aria-hidden="true"
               >
-                {content.name}
-              </Link>
-            </li>
-          ))}
-        </ul>
-      </div>
-    </aside>
+                <Link
+                  href={{
+                    pathname: '/',
+                    query: { leagueId: content.leagueId },
+                  }}
+                  className="flex items-center rounded-lg p-2 hover:bg-gray-2 dark:text-white dark:hover:bg-gray-5"
+                >
+                  {content.name}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </aside>
+    )
   );
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -20,7 +20,7 @@ export default function Header() {
   return (
     <header
       className={$(
-        'flex items-center justify-between p-4',
+        'relative flex items-center justify-between p-4',
         isAuthenticated && 'bg-primary text-white',
       )}
     >
@@ -37,7 +37,7 @@ export default function Header() {
           {isAuthenticated && <span>관리자</span>}
         </Link>
       </div>
-      <section>
+      <div>
         <button onClick={toggleSidebar}>
           <Icon
             iconName="HamburgerMenu"
@@ -49,8 +49,9 @@ export default function Header() {
             )}
           />
         </button>
-        {isSidebarOpen && <Sidebar onClickSidebar={toggleSidebar} />}
-      </section>
+
+        <Sidebar isSidebarOpen={isSidebarOpen} onClickSidebar={toggleSidebar} />
+      </div>
     </header>
   );
 }


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #88 

## ✅ 작업 내용

- 이제 사이드바 범위가 `main`을 기준으로 적용됩니다.
  - 사이드바 오픈 시 트랜지션이 적용됩니다.
  - 사이드바 닫을 때 트랜지션도 기입해놨으나 적용되지 않는 버그가 있습니다.

## 📝 참고 자료

- 작업한 내용에 대한 부연 설명

## ♾️ 기타

- 추가로 필요한 작업 내용
