### PR TITLE
[FIX]: 빌드 에러 픽스

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,5 +1,7 @@
 import axios from 'axios';
 
+import LocalStorage from '@/utils/LocalStorage';
+
 const instance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
   headers: {
@@ -16,7 +18,7 @@ export const adminInstance = axios.create({
 });
 
 adminInstance.interceptors.request.use(config => {
-  config.headers.Authorization = `Bearer ${localStorage.getItem('token')}`;
+  config.headers.Authorization = `Bearer ${LocalStorage.getItem('token')}`;
 
   return config;
 });

--- a/src/app/admin/league/page.tsx
+++ b/src/app/admin/league/page.tsx
@@ -1,11 +1,18 @@
 'use client';
 
+import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import { Suspense } from 'react';
 
-import LeagueList from '@/components/admin/league/LeagueList';
 import Button from '@/components/common/Button';
-import LeagueListFetcher from '@/queries/admin/useLeagueList/Fetcher';
+
+const LeagueListFetcher = dynamic(
+  () => import('@/queries/admin/useLeagueList/Fetcher'),
+  { ssr: false },
+);
+const LeagueList = dynamic(
+  () => import('@/components/admin/league/LeagueList'),
+);
 
 export default function LeaguePage() {
   return (

--- a/src/app/admin/register/[leagueId]/page.tsx
+++ b/src/app/admin/register/[leagueId]/page.tsx
@@ -2,15 +2,11 @@
 
 import { Suspense } from 'react';
 
-import RegisterLeague from '@/components/admin/register/League';
+import EditLeague from '@/components/admin/register/League/edit';
 import LeagueRegisterFetcher from '@/queries/admin/useLeagueRegister/Fetcher';
 import useSportsListByLeagueId from '@/queries/useSportsListByLeagueId/query';
 
-export default function EditLeague({
-  params,
-}: {
-  params: { leagueId: string };
-}) {
+export default function Edit({ params }: { params: { leagueId: string } }) {
   const { leagueId } = params;
   const { sportsList: leagueSportsData } = useSportsListByLeagueId(leagueId);
   return (
@@ -18,7 +14,7 @@ export default function EditLeague({
       <Suspense fallback={<div>리그 정보 로딩중...</div>}>
         <LeagueRegisterFetcher>
           {data => (
-            <RegisterLeague
+            <EditLeague
               data={{ ...data, leagueSportsData }}
               leagueId={Number(leagueId)}
             />

--- a/src/app/admin/register/page.tsx
+++ b/src/app/admin/register/page.tsx
@@ -3,7 +3,7 @@
 import { Suspense } from 'react';
 
 import RegisterWrapper from '@/components/admin/register/context/RegisterWrapper';
-import RegisterLeague from '@/components/admin/register/League';
+import RegisterLeague from '@/components/admin/register/League/';
 import RegisterTeam from '@/components/admin/register/Team';
 import { useFunnel } from '@/hooks/useFunnel';
 import LeagueRegisterFetcher from '@/queries/admin/useLeagueRegister/Fetcher';

--- a/src/components/admin/register/League/edit/index.tsx
+++ b/src/components/admin/register/League/edit/index.tsx
@@ -11,16 +11,21 @@ import {
   usePostLeagueMutation,
   usePutLeagueMutation,
 } from '@/queries/admin/useLeagueRegister/query';
-import { LeagueDataType, LeagueRegisterDataType } from '@/types/admin/league';
+import {
+  LeagueDataType,
+  LeagueRegisterDataType,
+  SportsDataType,
+} from '@/types/admin/league';
+import { SportsType } from '@/types/league';
 import { updateSet } from '@/utils/set';
 import { parseTimeString } from '@/utils/time';
 
-export default function RegisterLeague({
+export default function EditLeague({
   data,
   leagueId,
   onNext,
 }: {
-  data: LeagueRegisterDataType;
+  data: LeagueRegisterDataType & { leagueSportsData: SportsType[] };
   leagueId?: number;
   onNext?: () => void;
 }) {
@@ -29,7 +34,7 @@ export default function RegisterLeague({
   );
   const [newSportsData, setNewSportsData] = useState<Set<number>>(new Set());
 
-  const { leagueData, sportsListData } = data;
+  const { leagueData, leagueSportsData, sportsListData } = data;
   const currentLeague = leagueData.find(e => e.leagueId === Number(leagueId));
 
   const router = useRouter();
@@ -46,6 +51,14 @@ export default function RegisterLeague({
         startAt: parseDate(currentLeague.startAt),
         endAt: parseDate(currentLeague.endAt),
       });
+    }
+    if (leagueSportsData) {
+      const reducedSportsData = leagueSportsData.reduce(
+        (acc, cur) => [...acc, cur.sportId],
+        [] as SportsDataType,
+      );
+
+      setNewSportsData(new Set(reducedSportsData));
     }
   }, []);
 

--- a/src/components/common/Sidebar/index.tsx
+++ b/src/components/common/Sidebar/index.tsx
@@ -3,8 +3,8 @@
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 
-import { getAllLeaguesWithAuth } from '@/api/admin/league';
-import { LeagueType } from '@/types/admin/league';
+import { getAllLeagues } from '@/api/league';
+import { LeagueType } from '@/types/league';
 
 type SidebarProps = {
   isSidebarOpen: boolean;
@@ -15,12 +15,12 @@ export default function Sidebar({
   onClickSidebar,
 }: SidebarProps) {
   const [menuContent, setMenuContent] = useState<LeagueType[]>([
-    { name: '전체', leagueId: 0, startAt: '', endAt: '' },
+    { name: '전체', leagueId: 0 },
   ]);
 
   useEffect(() => {
     const getLeagueData = async () => {
-      const res = await getAllLeaguesWithAuth();
+      const res = await getAllLeagues();
 
       setMenuContent(prev => [...prev, ...res]);
     };

--- a/src/types/admin/league.ts
+++ b/src/types/admin/league.ts
@@ -33,6 +33,5 @@ export type DeleteLeaguePayload = LeagueIdType;
 
 export type LeagueRegisterDataType = {
   leagueData: LeagueType[];
-  leagueSportsData?: SportsCategoriesType[];
   sportsListData: SportsCategoriesType[];
 };

--- a/src/utils/LocalStorage.ts
+++ b/src/utils/LocalStorage.ts
@@ -1,0 +1,25 @@
+class LocalStorage {
+  constructor() {}
+
+  static setItem(key: string, value: string) {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(key, value);
+    }
+  }
+
+  static getItem(key: string) {
+    if (typeof window !== 'undefined') {
+      return localStorage.getItem(key);
+    }
+
+    return null;
+  }
+
+  static removeItem(key: string) {
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem(key);
+    }
+  }
+}
+
+export default LocalStorage;


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #105 

## ✅ 작업 내용

- 빌드 에러 픽스를 위해 몇가지 기능을 고쳤습니다.
  - 컴포넌트 props에 undefined 값을 부여해주면 좋지 못하다는 공식문서의 글귀를 봐서 이를 개선하고자 컴포넌트를 분리했습니다.
  - 원래 RegisterLeague 컴포넌트에서 leagueSportsData가 있는 경우와 없는 경우 모두 한꺼번에 받아 처리해줬는데, 아예 edit/register로 분리해 리그 수정은 edit, 새 리그 등록은 register로 라우팅하게 해줬습니다.
  - 빌드타임에서 어드민 인스턴스 인터셉터가 로컬스토리지를 호출할 때 윈도우 객체가 있을 때만 로컬스토리지를 호출할 수 있도록 LocalStorage 클래스 객체를 씌워줬습니다.
  - (가장 중요) /admin/league/page.tsx에서 LeagueListFetcher와 LeagueList를 lazy loading하도록 변경했습니다.
    - 의문인 점은 다른 league/register 페이지에서 똑같은 구조를 가지고 있는데 왜 league/page.tsx의 컴포넌트들만 서버사이드렌더링을 막아주면 빌드가 성공하는지 모르겠습니다..
    - https://nextjs.org/docs/app/building-your-application/optimizing/lazy-loading
