### PR TITLE
[FEAT] Vercel Analytics 설치 및 세팅

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@stomp/stompjs": "^7.0.0",
     "@tanstack/react-query": "^5.8.2",
     "@tanstack/react-query-devtools": "^5.8.2",
+    "@vercel/analytics": "^1.1.1",
     "axios": "^1.5.1",
     "clsx": "^2.0.0",
     "next": "13.5.4",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import './globals.css';
 
+import { Analytics } from '@vercel/analytics/react';
 import type { Metadata } from 'next';
 import { Noto_Sans_KR } from 'next/font/google';
 
@@ -31,7 +32,10 @@ export default function RootLayout({
       <body className={`${inter.className} m-auto max-w-md`}>
         <ReactQueryProvider>
           <Header />
-          <main className="px-4">{children}</main>
+          <main className="px-4">
+            {children}
+            <Analytics />
+          </main>
           <Footer />
         </ReactQueryProvider>
       </body>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1004,6 +1004,13 @@
     "@typescript-eslint/types" "6.9.1"
     eslint-visitor-keys "^3.4.1"
 
+"@vercel/analytics@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@vercel/analytics/-/analytics-1.1.1.tgz#2a712378a95014a548b4f9d2ae1ea0721433908d"
+  integrity sha512-+NqgNmSabg3IFfxYhrWCfB/H+RCUOCR5ExRudNG2+pcRehq628DJB5e1u1xqwpLtn4pAYii4D98w7kofORAGQA==
+  dependencies:
+    server-only "^0.0.1"
+
 JSONStream@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
@@ -4065,6 +4072,11 @@ semver@^6.3.0, semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
+server-only@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/server-only/-/server-only-0.0.1.tgz#0f366bb6afb618c37c9255a314535dc412cd1c9e"
+  integrity sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==
 
 set-function-name@^2.0.0, set-function-name@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #107 

## ✅ 작업 내용

- Vercel의 Analytics 의존성을 설치했습니다.
  - layout.tsx에 Analytics 모듈을 끼워넣었습니다.

## 📝 참고 자료

- https://vercel.com/docs/analytics/quickstart
