### PR TITLE
[FIX] 경기 시간의 분을 두자리로 출력

### DIFF
--- a/src/api/match.ts
+++ b/src/api/match.ts
@@ -14,9 +14,9 @@ import { convertObjectToQueryString } from '@/utils/queryString';
 import instance from '.';
 
 export type MatchListParams = {
-  sportsId?: string[];
+  sport_id?: string[];
   status: MatchStatus;
-  leagueId?: string;
+  league_id?: string;
   cursor?: number;
 };
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,10 +22,10 @@ export default function Home() {
   return (
     <section className="flex flex-col items-center">
       <AsyncBoundary
-        errorFallback={() => <div>에러</div>}
+        errorFallback={() => <SportsList.Skeleton />}
         loadingFallback={<SportsList.Skeleton />}
       >
-        <SportsListFetcher leagueId={params.get(QUERY_PARAMS.league) || '1'}>
+        <SportsListFetcher leagueId={params.get('leagueId') || '39'}>
           {data => (
             <SportsList
               selectedId={paramsObj[QUERY_PARAMS.sports] as string[]}

--- a/src/components/common/MatchCard/pieces/Label.tsx
+++ b/src/components/common/MatchCard/pieces/Label.tsx
@@ -14,7 +14,8 @@ export default function Label({ className }: LabelProps) {
   return (
     <div className={$('flex items-center justify-between text-sm', className)}>
       <time>
-        {month}. {date}. {weekday}요일 {period} {hours}:{minutes}
+        {month}. {date}. {weekday}요일 {period} {hours}:
+        {minutes.toString().padStart(2, '0')}
       </time>
       <div className="text-right">
         {sportsName} {gameName}

--- a/src/components/common/Sidebar/index.tsx
+++ b/src/components/common/Sidebar/index.tsx
@@ -52,7 +52,7 @@ export default function Sidebar({
                 <Link
                   href={{
                     pathname: '/',
-                    query: { leagueId: content.leagueId },
+                    query: { league_id: content.leagueId },
                   }}
                   className="flex items-center rounded-lg p-2 hover:bg-gray-2 dark:text-white dark:hover:bg-gray-5"
                 >

--- a/src/components/match/CommentForm/index.tsx
+++ b/src/components/match/CommentForm/index.tsx
@@ -13,8 +13,8 @@ type CommentFormProps = {
 
 const teamColor = [
   'bg-cheer-left',
-  'bg-[#fb923c] ',
   'bg-cheer-right',
+  'bg-[#fb923c] ',
   'bg-[#22c55e]',
 ] as const;
 
@@ -25,7 +25,9 @@ export default function CommentForm({
   scrollToBottom,
 }: CommentFormProps) {
   const [inputValue, setInputValue] = useState('');
-  const [selectedTeamId, setSelectedTeamId] = useState<number>(1);
+  const [selectedTeamId, setSelectedTeamId] = useState<number>(
+    matchTeams[0].gameTeamId,
+  );
 
   const handleCommentSubmit = (
     e: FormEvent<HTMLFormElement>,

--- a/src/constants/queryParams.ts
+++ b/src/constants/queryParams.ts
@@ -1,5 +1,5 @@
 export const QUERY_PARAMS = {
   league: 'league_id',
-  sports: 'sports_id',
+  sports: 'sport_id',
   status: 'status',
 };

--- a/src/queries/useMatchList/Fetcher.tsx
+++ b/src/queries/useMatchList/Fetcher.tsx
@@ -26,7 +26,7 @@ export default function MatchListFetcher({
   ...props
 }: MatchListFetcherProps) {
   const { matchList, error, hasNextPage, fetchNextPage, isFetching } =
-    useMatchList(props satisfies { status: string });
+    useMatchList(props);
 
   if (error) throw error;
 

--- a/src/queries/useMatchList/query.ts
+++ b/src/queries/useMatchList/query.ts
@@ -3,18 +3,18 @@ import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
 import { getMatchList, MatchListParams } from '@/api/match';
 
 export const useMatchList = ({
-  sportsId,
+  sport_id,
   status = 'playing',
-  leagueId,
+  league_id,
 }: Omit<MatchListParams, 'cursor' | 'size'>) => {
   const { data, error, isFetching, hasNextPage, fetchNextPage } =
     useSuspenseInfiniteQuery({
-      queryKey: ['match-list', sportsId, status, leagueId],
+      queryKey: ['match-list', sport_id, status, league_id],
       queryFn: ({ pageParam }) =>
         getMatchList({
-          sportsId,
+          sport_id,
           status,
-          leagueId,
+          league_id,
           cursor: pageParam,
         }),
       initialPageParam: 0,

--- a/src/queries/useSportsListByLeagueId/Fetcher.tsx
+++ b/src/queries/useSportsListByLeagueId/Fetcher.tsx
@@ -9,28 +9,13 @@ type SportsListFetcherProps = {
   children: (data: SportsType[]) => ReactNode;
 };
 
-const DUMMY = [
-  {
-    sportId: 1,
-    name: '축구',
-  },
-  {
-    sportId: 3,
-    name: '농구',
-  },
-  {
-    sportId: 2,
-    name: '롤',
-  },
-];
-
 export default function SportsListFetcher({
   leagueId,
   children,
 }: SportsListFetcherProps) {
-  const { error } = useSportsListByLeagueId(leagueId);
+  const { sportsList, error } = useSportsListByLeagueId(leagueId);
 
   if (error) throw error;
 
-  return children(DUMMY);
+  return children(sportsList);
 }


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호

## ✅ 작업 내용

- minuts을 두자리로 출력
- 팀 순서에 따른 색상 변경
- 사이드바의 query params를 스네이크 케이스로 변경
- 초기 league id를 고정
  - 현재는 경기가 하나밖에 없어서 39로 고정해뒀습니다.
  - 추후 정확하게 정하면 좋을 것 같습니다.