### PR TITLE
fix: value가 없을 땐 query string 넘기지 않도록 수정

### DIFF
--- a/src/utils/queryString.ts
+++ b/src/utils/queryString.ts
@@ -12,6 +12,8 @@ export const convertObjectToQueryString = (params: {
   const queryString = new URLSearchParams();
 
   Object.entries(params).forEach(([key, value]) => {
+    if (!value) return;
+
     if (Array.isArray(value)) {
       value.forEach(valueItem => {
         queryString.append(toSnakeCase(key), valueItem || '');


### PR DESCRIPTION
## ✅ 작업 내용

- query string의 value가 없을 땐 key도 넘기지 않도록 수정
